### PR TITLE
RTK 재발급 로직 구현

### DIFF
--- a/src/main/java/com/example/jwttest/Util/ApiResponse.java
+++ b/src/main/java/com/example/jwttest/Util/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.example.jwttest.Util;
+
+public class ApiResponse<T> {
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    private final T data;
+
+    // Success response constructor
+    private ApiResponse(T data) {
+        this.isSuccess = true;
+        this.code = "200";
+        this.message = "Success";
+        this.data = data;
+    }
+
+    // Error response constructor (예시용, 현재 코드에서는 사용되지 않음)
+    private ApiResponse(String code, String message) {
+        this.isSuccess = false;
+        this.code = code;
+        this.message = message;
+        this.data = null;
+    }
+
+    public static <T> ApiResponse<T> onSuccess(T data) {
+        return new ApiResponse<>(data);
+    }
+
+    // 필요시 에러 응답 생성을 위한 메서드 추가 가능
+    public static <T> ApiResponse<T> onFailure(String code, String message) {
+        return new ApiResponse<>(code, message);
+    }
+
+    // Getter methods
+    public boolean isSuccess() { return isSuccess; }
+    public String getCode() { return code; }
+    public String getMessage() { return message; }
+    public T getData() { return data; }
+}

--- a/src/main/java/com/example/jwttest/Util/JwtUtil.java
+++ b/src/main/java/com/example/jwttest/Util/JwtUtil.java
@@ -1,6 +1,8 @@
 package com.example.jwttest.Util;
 
 import com.example.jwttest.PrincipalDetails;
+import com.example.jwttest.dto.JwtDto;
+import com.example.jwttest.service.PrincipalDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
@@ -8,8 +10,10 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -29,6 +33,7 @@ public class JwtUtil {
     private final Long accessExpMs;
     private final Long refreshExpMs;
     private final RedisUtil redisUtil;
+
 
     public JwtUtil(
             // 해당 @Value 값들은 yml에서 설정할 수 있다
@@ -152,6 +157,11 @@ public class JwtUtil {
             log.info("JWT 토큰이 잘못되었습니다.");
         }
     }
+
+
+
+
+
 
 
 }

--- a/src/main/java/com/example/jwttest/config/SecurityConfig.java
+++ b/src/main/java/com/example/jwttest/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.example.jwttest.config;
 
-import com.example.jwttest.JwtAuthenticationFilter;
+import com.example.jwttest.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,7 +12,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import com.example.jwttest.Util.JwtUtil;
 
@@ -23,6 +22,8 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtUtil jwtUtil;
+
+    private final String[] allowedUrls = {"/reissue", "/login"};
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -70,8 +71,9 @@ public class SecurityConfig {
         http.
                 authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
+                                .requestMatchers(allowedUrls).permitAll()
                                 .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 접근 허용
-                                .requestMatchers("/user/**","/reissue").authenticated()
+                                .requestMatchers("/user/**").authenticated()
                                 .requestMatchers("/manager/**").hasAnyRole("ADMIN", "MANAGE")
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
                                 .anyRequest().permitAll()

--- a/src/main/java/com/example/jwttest/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/jwttest/config/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
-package com.example.jwttest;
+package com.example.jwttest.config.jwt;
 
+import com.example.jwttest.PrincipalDetails;
 import com.example.jwttest.Util.HttpResponseUtil;
 import com.example.jwttest.dto.JwtDto;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/example/jwttest/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/jwttest/config/jwt/JwtAuthorizationFilter.java
@@ -1,5 +1,6 @@
-package com.example.jwttest;
+package com.example.jwttest.config.jwt;
 
+import com.example.jwttest.PrincipalDetails;
 import com.example.jwttest.Util.HttpResponseUtil;
 import com.example.jwttest.Util.JwtUtil;
 import com.example.jwttest.Util.RedisUtil;

--- a/src/main/java/com/example/jwttest/controller/IndexController.java
+++ b/src/main/java/com/example/jwttest/controller/IndexController.java
@@ -1,0 +1,20 @@
+package com.example.jwttest.controller;
+
+import com.example.jwttest.Util.ApiResponse;
+import com.example.jwttest.dto.JwtDto;
+import com.example.jwttest.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class IndexController {
+    private final AuthService authService;
+    @GetMapping("/reissue")
+    public ApiResponse<JwtDto> reissueToken(@RequestHeader("RefreshToken") String refreshToken) {
+        return ApiResponse.onSuccess(authService.reissueToken(refreshToken));
+    }
+
+}

--- a/src/main/java/com/example/jwttest/exception/SecurityCustomException.java
+++ b/src/main/java/com/example/jwttest/exception/SecurityCustomException.java
@@ -1,0 +1,18 @@
+package com.example.jwttest.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SecurityCustomException extends RuntimeException {
+    private final TokenErrorCode errorCode;
+
+    public SecurityCustomException(TokenErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public SecurityCustomException(TokenErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/jwttest/exception/TokenErrorCode.java
+++ b/src/main/java/com/example/jwttest/exception/TokenErrorCode.java
@@ -1,0 +1,18 @@
+package com.example.jwttest.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TokenErrorCode {
+    INVALID_TOKEN("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_UNSUPPORTED("지원하지 않는 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_MALFORMED("토큰 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    REFRESH_TOKEN_NOT_FOUND("리프레시 토큰을 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/com/example/jwttest/service/AuthService.java
+++ b/src/main/java/com/example/jwttest/service/AuthService.java
@@ -1,0 +1,46 @@
+package com.example.jwttest.service;
+
+import com.example.jwttest.PrincipalDetails;
+import com.example.jwttest.Util.JwtUtil;
+import com.example.jwttest.dto.JwtDto;
+import com.example.jwttest.Util.RedisUtil;
+
+import com.example.jwttest.exception.SecurityCustomException;
+import com.example.jwttest.exception.TokenErrorCode;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
+    private final PrincipalDetailsService principalDetailsService;
+
+    public boolean validateRefreshToken(String refreshToken) {
+        // refreshToken validate
+        String username = jwtUtil.getUsername(refreshToken);
+
+        //redis 확인
+        if (!redisUtil.hasKey(username)) {
+            throw new SecurityCustomException(TokenErrorCode.INVALID_TOKEN);
+        }
+        return true;
+    }
+    public JwtDto reissueToken(String refreshToken) throws SignatureException {
+        String username = jwtUtil.getUsername(refreshToken);
+
+        UserDetails userDetails = principalDetailsService.loadUserByUsername(username);
+
+        PrincipalDetails principalDetails = (PrincipalDetails) userDetails;
+
+        return new JwtDto(
+                jwtUtil.createJwtAccessToken(principalDetails),
+                jwtUtil.createJwtRefreshToken(principalDetails)
+        );
+    }
+
+}


### PR DESCRIPTION
RTK 토큰에 대해서는 서비스 레이어에서 처리
토큰을 재발급하기 위해서는 principalservice 클래스의 의존성 주입이 필요한데,
유틸 클래스에 주입하는건 유틸 클래스 목적에 맞지 않다고 생각하여
RTK 토큰에 대한 처리를 해줄 서비스 레이어를 만들었다.