### PR TITLE
로그아웃 구현

### DIFF
--- a/src/main/java/com/example/jwttest/config/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/jwttest/config/jwt/JwtAuthorizationFilter.java
@@ -43,6 +43,13 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 return;
             }
 
+            // logout 처리된 accessToken
+            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
+                logger.info("[*] Logout accessToken");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             // 유효성 검사
             jwtUtil.validateToken(accessToken);
 
@@ -52,6 +59,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                     null,
                     jwtUtil.getRoles(accessToken)
             );
+
 
             // 스프링 시큐리티 인증 토큰 생성
             Authentication authToken = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/example/jwttest/config/jwt/JwtLogoutFilter.java
+++ b/src/main/java/com/example/jwttest/config/jwt/JwtLogoutFilter.java
@@ -1,0 +1,53 @@
+package com.example.jwttest.config.jwt;
+
+import com.example.jwttest.Util.HttpResponseUtil;
+import com.example.jwttest.Util.JwtUtil;
+import com.example.jwttest.Util.RedisUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtLogoutFilter implements LogoutHandler {
+
+    private final RedisUtil redisUtil;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        try {
+            log.info("[*] Logout Filter");
+
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            redisUtil.save(
+                    accessToken,
+                    "logout",
+                    jwtUtil.getExpTime(accessToken),
+                    TimeUnit.MILLISECONDS
+            );
+
+            String username = jwtUtil.getUsername(accessToken);
+
+            //username으로 가지고 있는 RTK 삭제
+            redisUtil.delete(username);
+
+        } catch (ExpiredJwtException e) {
+            log.warn("[*] case : accessToken expired");
+            try {
+                HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인하세요",null);
+            } catch (IOException ex) {
+                log.error("IOException occurred while setting error response: {}", ex.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## JwtLogoutFilter 
- AccessToken을 블랙리스트 처리하여 redis에 저장한다. (accessToken : "logout")
- AccessToken에서 추출한 username을 key로 가지고 있는 value(RefreshToken)을 삭제한다.
- SecurityConfig에 추가

## JwtAuthorizationFilter 인가단계 수정
- 매번 logout 된 토큰인지 체크 해주는 로직을 추가한다