### PR TITLE
카카오 OAuth 연동 및 수정

### DIFF
--- a/src/main/java/com/example/jwttest/Util/ApiResponse.java
+++ b/src/main/java/com/example/jwttest/Util/ApiResponse.java
@@ -14,7 +14,6 @@ public class ApiResponse<T> {
         this.data = data;
     }
 
-    // Error response constructor (예시용, 현재 코드에서는 사용되지 않음)
     private ApiResponse(String code, String message) {
         this.isSuccess = false;
         this.code = code;

--- a/src/main/java/com/example/jwttest/Util/KakaoUtil.java
+++ b/src/main/java/com/example/jwttest/Util/KakaoUtil.java
@@ -1,0 +1,83 @@
+package com.example.jwttest.Util;
+
+import com.example.jwttest.dto.KakaoDto;
+import com.example.jwttest.exception.AuthHandler;
+import com.example.jwttest.exception.ErrorStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+@Component
+@Slf4j
+public class KakaoUtil {
+
+    @Value("${spring.kakao.auth.client}")
+    private String client;
+    @Value("${spring.kakao.auth.redirect}")
+    private String redirect;
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public KakaoDto.OAuthToken requestToken(String accessCode) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", client);
+        params.add("redirect_url", redirect);
+        params.add("code", accessCode);
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class);
+        KakaoDto.OAuthToken oAuthToken = null;
+
+        try {
+            oAuthToken = objectMapper.readValue(response.getBody(), KakaoDto.OAuthToken.class);
+            log.info("oAuthToken : " + oAuthToken.getAccess_token());
+        } catch (JsonProcessingException e) {
+            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+        }
+        return oAuthToken;
+    }
+    public KakaoDto.KakaoProfile requestProfile(KakaoDto.OAuthToken oAuthToken) {
+        RestTemplate restTemplate2 = new RestTemplate();
+        HttpHeaders headers2 = new HttpHeaders();
+
+        headers2.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers2.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
+
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers2);
+
+        ResponseEntity<String> response2 = restTemplate2.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                kakaoProfileRequest,
+                String.class);
+        KakaoDto.KakaoProfile KakaoProfile = null;
+        String responseBody = response2.getBody();
+        log.info("카카오 프로필 응답 데이터: " + responseBody); // 추가 필요
+        try {
+            KakaoProfile = objectMapper.readValue(response2.getBody(), KakaoDto.KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            log.info(Arrays.toString(e.getStackTrace()));
+            throw new AuthHandler(ErrorStatus._PARSING_ERROR);
+        }
+
+        return KakaoProfile;
+    }
+}

--- a/src/main/java/com/example/jwttest/config/Auth/RestTemplateConfig.java
+++ b/src/main/java/com/example/jwttest/config/Auth/RestTemplateConfig.java
@@ -1,0 +1,25 @@
+package com.example.jwttest.config.Auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+        messageConverters.add(new FormHttpMessageConverter());
+        restTemplate.setMessageConverters(messageConverters);
+
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/example/jwttest/config/SecurityConfig.java
+++ b/src/main/java/com/example/jwttest/config/SecurityConfig.java
@@ -28,7 +28,11 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
 
-    private final String[] allowedUrls = {"/reissue", "/login"};
+    private final String[] allowedUrls = {
+            "/reissue",
+            "/login",
+            "/auth/login/kakao/**",
+    };
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
@@ -66,7 +70,6 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-        // 경로별 인가
 //        http
 //                .headers(headers ->
 //                        headers.frameOptions(frameOptions ->

--- a/src/main/java/com/example/jwttest/controller/AuthController.java
+++ b/src/main/java/com/example/jwttest/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.example.jwttest.controller;
+
+import com.example.jwttest.Util.ApiResponse;
+import com.example.jwttest.converter.UserConverter;
+import com.example.jwttest.domain.User;
+import com.example.jwttest.dto.AuthResponseDto;
+import com.example.jwttest.dto.UserResponseDto;
+import com.example.jwttest.service.AuthService;
+import com.example.jwttest.dto.JwtDto;
+import com.example.jwttest.repository.UserRepository;
+import com.example.jwttest.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("")
+public class AuthController {
+    private final AuthService authService;
+    @GetMapping("/auth/login/kakao")
+    public ApiResponse<AuthResponseDto> kakaoLogin(@RequestParam("code") String accessCode) {
+        return ApiResponse.onSuccess(authService.oAuthLogin(accessCode));
+    }
+
+}

--- a/src/main/java/com/example/jwttest/converter/AuthConverter.java
+++ b/src/main/java/com/example/jwttest/converter/AuthConverter.java
@@ -1,0 +1,19 @@
+package com.example.jwttest.converter;
+
+
+import com.example.jwttest.domain.User;
+import lombok.Builder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Builder
+public class AuthConverter {
+
+    public static User toUser(Long kakaoid,String name, String password, PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .kakaoid(kakaoid)
+                .role("ROLE_USER")
+                .password(passwordEncoder.encode(password))
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/example/jwttest/converter/AuthConverter.java
+++ b/src/main/java/com/example/jwttest/converter/AuthConverter.java
@@ -14,6 +14,7 @@ public class AuthConverter {
                 .role("ROLE_USER")
                 .password(passwordEncoder.encode(password))
                 .name(name)
+                .username("kakao_" + kakaoid) // Add username generation
                 .build();
     }
 }

--- a/src/main/java/com/example/jwttest/converter/UserConverter.java
+++ b/src/main/java/com/example/jwttest/converter/UserConverter.java
@@ -1,0 +1,18 @@
+package com.example.jwttest.converter;
+
+import com.example.jwttest.domain.User;
+import com.example.jwttest.dto.UserResponseDto;
+
+public class UserConverter {
+
+    public static UserResponseDto.JoinResultDTO toJoinResultDTO(User user) {
+        return UserResponseDto.JoinResultDTO.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .name(user.getName())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .kakaoId(user.getKakaoid() != null ? Long.valueOf(user.getKakaoid()) : null)
+                .build();
+    }
+}

--- a/src/main/java/com/example/jwttest/domain/User.java
+++ b/src/main/java/com/example/jwttest/domain/User.java
@@ -2,6 +2,8 @@ package com.example.jwttest.domain;
 
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -14,15 +16,19 @@ import java.util.List;
 @Data
 @Entity
 @Table(name = "users")
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class User {
     @Id // primary key
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int id;
+    private Long id;
+    private Long kakaoid;
     private String username;
     private String password;
     private String email;
     private String role; //ROLE_USER, ROLE_ADMIN
+    private String name;
     @CreationTimestamp
     private Timestamp createDate;
 
@@ -38,4 +44,5 @@ public class User {
         }
         return new ArrayList<>();
     }
+
 }

--- a/src/main/java/com/example/jwttest/dto/AuthResponseDto.java
+++ b/src/main/java/com/example/jwttest/dto/AuthResponseDto.java
@@ -1,0 +1,9 @@
+package com.example.jwttest.dto;
+
+import com.example.jwttest.dto.UserResponseDto;
+
+public record AuthResponseDto(
+        UserResponseDto.JoinResultDTO user,
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/example/jwttest/dto/KakaoDto.java
+++ b/src/main/java/com/example/jwttest/dto/KakaoDto.java
@@ -1,6 +1,9 @@
 package com.example.jwttest.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 
 public class KakaoDto {
 
@@ -14,33 +17,49 @@ public class KakaoDto {
         private int refresh_token_expires_in;
     }
 
-    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Getter @Setter
     public static class KakaoProfile {
         private Long id;
-        private String connected_at;
-        private Properties properties;
-        private KakaoAccount kakao_account;
+        @JsonProperty("connected_at")
+        private String connectedAt;
 
-        @Getter
-        public class Properties {
-            private String nickname;
-        }
+        @JsonProperty("kakao_account")
+        private KakaoAccount kakaoAccount;
 
-        @Getter
-        public class KakaoAccount {
-            private String email;
-            private Boolean is_email_verified;
-            private Boolean has_email;
-            private Boolean profile_nickname_needs_agreement;
-            private Boolean email_needs_agreement;
-            private Boolean is_email_valid;
+        @JsonProperty("properties")
+        private ProfileProperties properties;
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @Getter @Setter
+        public static class KakaoAccount {
+            @JsonProperty("profile_nickname_needs_agreement")
+            private Boolean profileNicknameNeedsAgreement;
+            @JsonProperty("profile_image_needs_agreement")
+            private Boolean profileImageNeedsAgreement;
             private Profile profile;
 
-            @Getter
-            public class Profile {
+            @JsonIgnoreProperties(ignoreUnknown = true)
+            @Getter @Setter
+            public static class Profile {
                 private String nickname;
-                private Boolean is_default_nickname;
+                @JsonProperty("thumbnail_image_url")
+                private String thumbnailImageUrl;
+                @JsonProperty("profile_image_url")
+                private String profileImageUrl;
+                @JsonProperty("is_default_image")
+                private Boolean isDefaultImage;
             }
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @Getter @Setter
+        public static class ProfileProperties {
+            private String nickname;
+            @JsonProperty("profile_image")
+            private String profileImage;
+            @JsonProperty("thumbnail_image")
+            private String thumbnailImage;
         }
     }
 }

--- a/src/main/java/com/example/jwttest/dto/KakaoDto.java
+++ b/src/main/java/com/example/jwttest/dto/KakaoDto.java
@@ -1,0 +1,46 @@
+package com.example.jwttest.dto;
+
+import lombok.Getter;
+
+public class KakaoDto {
+
+    @Getter
+    public static class OAuthToken {
+        private String access_token;
+        private String token_type;
+        private String refresh_token;
+        private int expires_in;
+        private String scope;
+        private int refresh_token_expires_in;
+    }
+
+    @Getter
+    public static class KakaoProfile {
+        private Long id;
+        private String connected_at;
+        private Properties properties;
+        private KakaoAccount kakao_account;
+
+        @Getter
+        public class Properties {
+            private String nickname;
+        }
+
+        @Getter
+        public class KakaoAccount {
+            private String email;
+            private Boolean is_email_verified;
+            private Boolean has_email;
+            private Boolean profile_nickname_needs_agreement;
+            private Boolean email_needs_agreement;
+            private Boolean is_email_valid;
+            private Profile profile;
+
+            @Getter
+            public class Profile {
+                private String nickname;
+                private Boolean is_default_nickname;
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/jwttest/dto/UserResponseDto.java
+++ b/src/main/java/com/example/jwttest/dto/UserResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.jwttest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class JoinResultDTO {
+        private Long id;
+        private String username;
+        private String name;
+        private String email;
+        private String role;
+        private Long kakaoId;
+    }
+}

--- a/src/main/java/com/example/jwttest/exception/AuthHandler.java
+++ b/src/main/java/com/example/jwttest/exception/AuthHandler.java
@@ -1,0 +1,27 @@
+package com.example.jwttest.exception;
+
+import lombok.Getter;
+
+@Getter
+public class AuthHandler extends RuntimeException {
+    private final ErrorStatus errorStatus;
+
+    public AuthHandler(ErrorStatus errorStatus) {
+        super(errorStatus.getMessage());
+        this.errorStatus = errorStatus;
+    }
+
+    public AuthHandler(ErrorStatus errorStatus, String customMessage) {
+        super(customMessage);
+        this.errorStatus = errorStatus;
+    }
+
+    public AuthHandler(ErrorStatus errorStatus, Throwable cause) {
+        super(errorStatus.getMessage(), cause);
+        this.errorStatus = errorStatus;
+    }
+
+    public int getHttpStatus() {
+        return errorStatus.getHttpStatus().value();
+    }
+}

--- a/src/main/java/com/example/jwttest/exception/ErrorStatus.java
+++ b/src/main/java/com/example/jwttest/exception/ErrorStatus.java
@@ -1,0 +1,30 @@
+package com.example.jwttest.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus {
+    // 공통 오류
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+
+    // 파싱 관련 오류
+    _PARSING_ERROR(HttpStatus.BAD_REQUEST, "데이터 파싱 중 오류가 발생했습니다."),
+
+    // 인증 관련 오류
+    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    _EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+
+    // OAuth 관련 오류
+    _OAUTH_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 서버와 통신 중 오류가 발생했습니다."),
+    _OAUTH_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, "OAuth 사용자 정보를 가져오는 데 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/example/jwttest/repository/UserRepository.java
+++ b/src/main/java/com/example/jwttest/repository/UserRepository.java
@@ -8,5 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long id);
     Optional<User> findByUsername(String username);
+    Optional<User> findByKakaoid(Long kakaoid);
 }

--- a/src/main/java/com/example/jwttest/service/AuthService.java
+++ b/src/main/java/com/example/jwttest/service/AuthService.java
@@ -21,6 +21,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +61,11 @@ public class AuthService {
     }
 
     private User createNewUser(KakaoDto.KakaoProfile kakaoProfile) {
+        String tempPassword = UUID.randomUUID().toString();
         User newUser = AuthConverter.toUser(
                 kakaoProfile.getId(),
-                kakaoProfile.getKakao_account().getProfile().getNickname(),
-                null,
+                kakaoProfile.getKakaoAccount().getProfile().getNickname(),
+                tempPassword,
                 passwordEncoder
         );
         return userRepository.save(newUser);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  kakao:
+    auth:
+      client: d4e9bbcffde5311cf9a15f8d8da718d9
+      redirect: http://localhost:8080/auth/login/kakao


### PR DESCRIPTION
## OAuth 연동 

- 서비스 서버에서 카카오 인증 서버에 요청을 보내기 위해 restTemplate 생성
인가코드를 받아서 인증 서버에 토큰을 요청하기 위해 서비스 서버에서 카카오 인증 서버에 요청을 보낼 restTemplate  생성

- 카카오 서버의 응답에 맞춰 kakao dto 수정

- spring security는 password 를 null로 받지 않기 때문에, default password 생성