### PR TITLE
Feature/login

### DIFF
--- a/src/main/java/com/example/trace/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trace/JwtAuthenticationFilter.java
@@ -1,0 +1,88 @@
+package com.example.trace;
+
+
+import com.example.trace.domain.User;
+import com.example.trace.dto.PrincipalDetails;
+import com.example.trace.Util.HttpResponseUtil;
+import com.example.trace.Util.JwtUtil;
+import com.example.trace.Util.RedisUtil;
+import com.example.trace.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+        log.info("[*] Jwt Filter");
+
+        try {
+            String accessToken = jwtUtil.resolveAccessToken(request);
+
+            // accessToken 없이 접근할 경우
+            if (accessToken == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // logout 처리된 accessToken
+            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
+                logger.info("[*] Logout accessToken");
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 유효성 검사
+            jwtUtil.validateToken(accessToken);
+
+            // accessToken에서 providerId 추출
+            String providerId = jwtUtil.getProviderId(accessToken);
+            // accessToken에서 providerId로 User 객체를 가져옴
+            User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            // accesstoken을 기반으로 principalDetail 저장
+            PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+
+            // 스프링 시큐리티 인증 토큰 생성
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    principalDetails,
+                    null,
+                    principalDetails.getAuthorities());
+
+            // 컨텍스트 홀더에 저장
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            try {
+                HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, null,"엑세스 토큰이 유효하지 않습니다.");
+            } catch (IOException ex) {
+                log.error("IOException occurred while setting error response: {}", ex.getMessage());
+            }
+            log.warn("[*] case : accessToken Expired");
+        }
+    }
+}

--- a/src/main/java/com/example/trace/TraceApplication.java
+++ b/src/main/java/com/example/trace/TraceApplication.java
@@ -2,8 +2,10 @@ package com.example.trace;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class TraceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/trace/Util/HttpResponseUtil.java
+++ b/src/main/java/com/example/trace/Util/HttpResponseUtil.java
@@ -1,0 +1,43 @@
+package com.example.trace.Util;
+
+
+import org.springframework.http.HttpStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpResponseUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 성공 응답 설정
+    public static void setSuccessResponse(HttpServletResponse response, HttpStatus status, Object data) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", status.value());
+        responseBody.put("message", "Success");
+        responseBody.put("data", data);
+
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+
+    // 실패 응답 설정
+    public static void setErrorResponse(HttpServletResponse response, HttpStatus status, String error, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("status", status.value());
+        responseBody.put("error", error);
+        responseBody.put("message", message);
+
+        response.getWriter().write(objectMapper.writeValueAsString(responseBody));
+    }
+}

--- a/src/main/java/com/example/trace/Util/JwtUtil.java
+++ b/src/main/java/com/example/trace/Util/JwtUtil.java
@@ -1,0 +1,178 @@
+package com.example.trace.Util;
+
+import com.example.trace.dto.PrincipalDetails;
+import com.example.trace.Util.RedisUtil;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.security.core.GrantedAuthority;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Long accessExpMs;
+    private final Long refreshExpMs;
+    private final RedisUtil redisUtil;
+    byte[] decodedKey;
+
+
+    public JwtUtil(
+            // 해당 @Value 값들은 yml에서 설정할 수 있다
+            @Value("${spring.jwt.secret}") String secret,
+            @Value("${spring.jwt.token.access-expiration-time}") Long access,
+            @Value("${spring.jwt.token.refresh-expiration-time}") Long refresh,
+            RedisUtil redis) {
+        decodedKey = Base64.getDecoder().decode(secret);
+        if(decodedKey.length != 64) {
+            throw new IllegalArgumentException("HS512 requires 64 byte key");
+        }
+        secretKey = new SecretKeySpec(decodedKey, "HmacSHA512");
+        accessExpMs = access;
+        refreshExpMs = refresh;
+        redisUtil = redis;
+        log.info("Decoded Key Length: {} bytes", decodedKey.length);
+// HS256: 32 bytes, HS512: 64 bytes 여야 정상
+    }
+
+    // JWT 토큰을 입력으로 받아 토큰의 페이로드에서 사용자 이름(Username)을 추출
+    public String getProviderId(String token) throws SignatureException {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    // JWT 토큰을 입력으로 받아 토큰의 페이로드에서 사용자 이름(roll)을 추출
+    public String getRoles(String token) throws SignatureException{
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+    // JWT 토큰의 페이로드에서 만료 시간을 검색, 밀리초 단위의 Long 값으로 반환
+    public long getExpTime(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration()
+                .getTime();
+    }
+
+    public Long getKakaoId(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("kakaoid", Long.class);
+    }
+
+    // Token 발급
+    public String tokenProvider(PrincipalDetails principalDetails, Instant expiration) {
+        Instant issuedAt = Instant.now();
+        String authorities = principalDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .header()
+                .add("typ", "JWT")
+                .and()
+                .subject(principalDetails.getUser().getProviderId())
+                .claim("role", authorities)
+                .issuedAt(Date.from(issuedAt))
+                .expiration(Date.from(expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // principalDetails 객체에 대해 새로운 JWT 액세스 토큰을 생성
+    public String createJwtAccessToken(PrincipalDetails principalDetails) {
+        Instant expiration = Instant.now().plusMillis(accessExpMs);
+        return tokenProvider(principalDetails, expiration);
+    }
+
+    // principalDetails 객체에 대해 새로운 JWT 리프레시 토큰을 생성
+    public String createJwtRefreshToken(PrincipalDetails principalDetails) {
+        Instant expiration = Instant.now().plusMillis(refreshExpMs);
+        String refreshToken = tokenProvider(principalDetails, expiration);
+
+        // 레디스에 저장
+        redisUtil.save(
+                principalDetails.getUsername(),
+                refreshToken,
+                refreshExpMs,
+                TimeUnit.MILLISECONDS
+        );
+
+        return refreshToken;
+    }
+
+    // HTTP 요청의 'Authorization' 헤더에서 JWT 액세스 토큰을 검색
+    public String resolveAccessToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            log.warn("[*] No Token in req");
+            return null;
+        }
+        log.info("[*] Token exists");
+
+        return authorization.split(" ")[1];
+    }
+
+    // 토큰 유효성 검사
+    public void validateToken(String token) {
+        try {
+            // 구문 분석 시스템의 시계가 JWT를 생성한 시스템의 시계 오차 고려
+            // 약 3분 허용.
+            long seconds = 3 *60;
+            boolean isExpired = Jwts
+                    .parser()
+                    .clockSkewSeconds(seconds)
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getExpiration()
+                    .before(new Date());
+            log.info("[*] Authorization with Token");
+            if (isExpired) {
+                log.info("만료된 JWT 토큰입니다.");
+            }
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+    }
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/trace/Util/RedisUtil.java
+++ b/src/main/java/com/example/trace/Util/RedisUtil.java
@@ -1,0 +1,31 @@
+package com.example.trace.Util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.data.redis.core.RedisTemplate;
+import java.util.concurrent.TimeUnit;
+@Component
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisUtil(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+
+    public void save(String key, Object val, Long time, TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(key, val, time, timeUnit);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+}

--- a/src/main/java/com/example/trace/client/KakaoOAuthClient.java
+++ b/src/main/java/com/example/trace/client/KakaoOAuthClient.java
@@ -1,0 +1,17 @@
+package com.example.trace.client;
+
+import com.example.trace.models.OIDCPublicKeyResponse;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(
+        name = "KakaoOauthClient",
+        url = "${oauth2.client.provider.kakao.authorization-uri}",
+        configuration = KakaoOauthConfig.class
+)
+public interface KakaoOAuthClient {
+    @Cacheable(value = "KakaoOauth", cacheManager = "oidcCacheManager")
+    @GetMapping("/.well-known/jwks.json")
+    OIDCPublicKeyResponse getOIDCPublicKey();
+}

--- a/src/main/java/com/example/trace/client/KakaoOAuthClient.java
+++ b/src/main/java/com/example/trace/client/KakaoOAuthClient.java
@@ -7,11 +7,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @FeignClient(
         name = "KakaoOauthClient",
-        url = "${oauth2.client.provider.kakao.authorization-uri}",
+        url = "${oauth2.client.provider.kakao.jwks-uri}",
         configuration = KakaoOauthConfig.class
 )
 public interface KakaoOAuthClient {
     @Cacheable(value = "KakaoOauth", cacheManager = "oidcCacheManager")
-    @GetMapping("/.well-known/jwks.json")
+    @GetMapping("")
     OIDCPublicKeyResponse getOIDCPublicKey();
 }

--- a/src/main/java/com/example/trace/client/KakaoOauthConfig.java
+++ b/src/main/java/com/example/trace/client/KakaoOauthConfig.java
@@ -1,0 +1,26 @@
+package com.example.trace.client;
+
+import feign.Logger;
+import feign.Request;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class KakaoOauthConfig {
+    
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+    
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(
+            10, TimeUnit.SECONDS, // Connection timeout
+            10, TimeUnit.SECONDS, // Read timeout
+            true  // Follow redirects
+        );
+    }
+} 

--- a/src/main/java/com/example/trace/config/RedisConfig.java
+++ b/src/main/java/com/example/trace/config/RedisConfig.java
@@ -1,0 +1,72 @@
+package com.example.trace.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableRedisRepositories
+@EnableCaching
+public class RedisConfig {
+    
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+    
+    @Bean
+    @Qualifier("oidcCacheManager")
+    public CacheManager oidcCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()
+                        ))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        ))
+                .entryTtl(Duration.ofDays(3));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+    
+    @Bean
+    @Qualifier("tokenCacheManager")
+    public CacheManager tokenCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()
+                        ))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()
+                        ))
+                .entryTtl(Duration.ofHours(1));  // Cache temporary tokens for signup
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/com/example/trace/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/config/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.example.trace.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/v1/auth/oauth/**").permitAll()
+                .anyRequest().authenticated()
+            );
+        
+        return http.build();
+    }
+} 

--- a/src/main/java/com/example/trace/controller/OAuthController.java
+++ b/src/main/java/com/example/trace/controller/OAuthController.java
@@ -1,0 +1,34 @@
+package com.example.trace.controller;
+
+import com.example.trace.dto.KakaoLoginRequest;
+import com.example.trace.dto.KakaoSignupRequest;
+import com.example.trace.service.KakaoOAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth/oauth")
+@Slf4j
+public class OAuthController {
+    private final KakaoOAuthService kakaoOAuthService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody KakaoLoginRequest request) {
+        log.info("Received login request with id_token: {}", 
+                request.getIdToken().substring(0, Math.min(10, request.getIdToken().length())) + "...");
+        return kakaoOAuthService.processLogin(request);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody KakaoSignupRequest request) {
+        log.info("Received signup request with id_token: {}", 
+                request.getIdToken().substring(0, Math.min(10, request.getIdToken().length())) + "...");
+        return kakaoOAuthService.processSignup(request);
+    }
+}

--- a/src/main/java/com/example/trace/domain/User.java
+++ b/src/main/java/com/example/trace/domain/User.java
@@ -1,0 +1,31 @@
+package com.example.trace.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String providerId;
+
+    @Column(nullable = false)
+    private String provider;
+
+    private String email;
+
+    private String nickname;
+
+    private String profileImage;
+
+    // Add other fields as needed
+}

--- a/src/main/java/com/example/trace/domain/User.java
+++ b/src/main/java/com/example/trace/domain/User.java
@@ -3,6 +3,10 @@ package com.example.trace.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -16,7 +20,7 @@ public class User {
     private Long id;
 
     @Column(nullable = false)
-    private String providerId;
+    private String providerId; //provider에서 받아온 userId
 
     @Column(nullable = false)
     private String provider;
@@ -27,5 +31,15 @@ public class User {
 
     private String profileImage;
 
-    // Add other fields as needed
+    private String password;
+    private String username;
+    private String role;
+
+    public List<String> getRoleList() {
+        if(this.role != null && !this.role.isEmpty()) {
+            return Arrays.asList(this.role.split(","));
+        }
+        return new ArrayList<>();
+    }
+
 }

--- a/src/main/java/com/example/trace/dto/DeviceInfo.java
+++ b/src/main/java/com/example/trace/dto/DeviceInfo.java
@@ -1,0 +1,15 @@
+package com.example.trace.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DeviceInfo {
+    private String deviceId;
+    private String deviceModel;
+    private String osVersion;
+    private String appVersion;
+}

--- a/src/main/java/com/example/trace/dto/JwtDto.java
+++ b/src/main/java/com/example/trace/dto/JwtDto.java
@@ -1,0 +1,7 @@
+package com.example.trace.dto;
+
+public record JwtDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/example/trace/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/example/trace/dto/KakaoLoginRequest.java
@@ -1,0 +1,20 @@
+
+package com.example.trace.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoLoginRequest {
+    @NotBlank
+    private String userId;
+
+    @NotBlank
+    private String idToken;
+
+    private DeviceInfo deviceInfo;
+}

--- a/src/main/java/com/example/trace/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/example/trace/dto/KakaoLoginRequest.java
@@ -11,9 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class KakaoLoginRequest {
     @NotBlank
-    private String userId;
-
-    @NotBlank
     private String idToken;
 
     private DeviceInfo deviceInfo;

--- a/src/main/java/com/example/trace/dto/KakaoSignupRequest.java
+++ b/src/main/java/com/example/trace/dto/KakaoSignupRequest.java
@@ -14,6 +14,7 @@ public class KakaoSignupRequest {
     private String idToken;
 
     // Additional user information for signup
+    private Long ProviderId;
     private String nickname;
     private String email;
     private String profileImage;

--- a/src/main/java/com/example/trace/dto/KakaoSignupRequest.java
+++ b/src/main/java/com/example/trace/dto/KakaoSignupRequest.java
@@ -1,0 +1,23 @@
+
+package com.example.trace.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoSignupRequest {
+    @NotBlank
+    private String idToken;
+
+    // Additional user information for signup
+    private String nickname;
+    private String email;
+    private String profileImage;
+    // Add other necessary fields
+
+    private DeviceInfo deviceInfo;
+}

--- a/src/main/java/com/example/trace/dto/PrincipalDetails.java
+++ b/src/main/java/com/example/trace/dto/PrincipalDetails.java
@@ -1,0 +1,67 @@
+package com.example.trace.dto;
+
+
+import com.example.trace.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+@Getter
+public class PrincipalDetails implements UserDetails {
+
+    private final User user; // User 객체를 저장
+
+    public PrincipalDetails(User user) {
+        this.user = user;
+    }
+
+
+
+    // 해당 User의 권한을 리턴 하는 곳
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return user.getRoleList().stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        // 사이트에서 1년 동안 회원이 로그인을 안하면 -> 휴면 계정으로 전환하는 로직이 있다고 치자
+        // user entity의 field에 "Timestamp loginDate"를 하나 만들어주고
+        // (현재 시간 - loginDate) > 1년 -> return false; 로 설정
+        return true;
+    }
+}

--- a/src/main/java/com/example/trace/dto/SignupRequiredResponse.java
+++ b/src/main/java/com/example/trace/dto/SignupRequiredResponse.java
@@ -1,0 +1,15 @@
+package com.example.trace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SignupRequiredResponse {
+    private String userId;
+    private String email;
+    private String nickname;
+    private String profileImage;
+}

--- a/src/main/java/com/example/trace/dto/TokenResponse.java
+++ b/src/main/java/com/example/trace/dto/TokenResponse.java
@@ -1,0 +1,13 @@
+package com.example.trace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/trace/models/OIDCDecodePayload.java
+++ b/src/main/java/com/example/trace/models/OIDCDecodePayload.java
@@ -1,0 +1,21 @@
+package com.example.trace.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OIDCDecodePayload {
+    private String iss;
+    private String aud;
+    private String sub;  // user_id in Kakao
+    private long iat;
+    private long auth_time;
+    private long exp;
+    private String nonce;
+    private String nickname;
+    private String picture;
+    private String email;
+}

--- a/src/main/java/com/example/trace/models/OIDCPublicKey.java
+++ b/src/main/java/com/example/trace/models/OIDCPublicKey.java
@@ -1,0 +1,17 @@
+package com.example.trace.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OIDCPublicKey {
+    private String kid;
+    private String kty;
+    private String alg;
+    private String use;
+    private String n;  // modulus
+    private String e;  // exponent
+}

--- a/src/main/java/com/example/trace/models/OIDCPublicKeyResponse.java
+++ b/src/main/java/com/example/trace/models/OIDCPublicKeyResponse.java
@@ -1,0 +1,14 @@
+package com.example.trace.models;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OIDCPublicKeyResponse {
+    private List<OIDCPublicKey> keys;
+}

--- a/src/main/java/com/example/trace/provider/KakaoOIDCProvider.java
+++ b/src/main/java/com/example/trace/provider/KakaoOIDCProvider.java
@@ -1,0 +1,118 @@
+package com.example.trace.provider;
+
+import com.example.trace.client.KakaoOAuthClient;
+import com.example.trace.models.OIDCDecodePayload;
+import com.example.trace.models.OIDCPublicKey;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOIDCProvider implements OIDCProvider {
+    private static final String ISSUER = "https://kauth.kakao.com";
+
+    private final KakaoOAuthClient kakaoOAuthClient;
+
+    @Override
+    public String getKidFromUnsignedTokenHeader(String token) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length < 2) {
+                throw new IllegalArgumentException("Invalid token format");
+            }
+
+            String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+            JsonNode headerNode = new ObjectMapper().readTree(headerJson);
+
+            if (!headerNode.has("kid")) {
+                throw new IllegalArgumentException("No kid found in token header");
+            }
+
+            return headerNode.get("kid").asText();
+        } catch (Exception e) {
+            log.error("Error extracting kid from token header", e);
+            throw new IllegalArgumentException("Failed to parse token header", e);
+        }
+    }
+
+    @Override
+    public OIDCDecodePayload verifyAndDecodeToken(String token, String clientId) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length < 2) {
+                throw new IllegalArgumentException("Invalid token format");
+            }
+
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+            OIDCDecodePayload payload = new ObjectMapper().readValue(payloadJson, OIDCDecodePayload.class);
+
+            // Verify issuer
+            if (!ISSUER.equals(payload.getIss())) {
+                throw new IllegalArgumentException("Invalid token issuer");
+            }
+
+            // Verify audience
+            if (!clientId.equals(payload.getAud())) {
+                throw new IllegalArgumentException("Invalid token audience");
+            }
+
+            // Verify expiration
+            if (payload.getExp() < System.currentTimeMillis() / 1000) {
+                throw new IllegalArgumentException("Token has expired");
+            }
+
+            // We don't verify nonce here as it would have been provided by the client initially
+
+            return payload;
+        } catch (Exception e) {
+            log.error("Error decoding token payload", e);
+            throw new IllegalArgumentException("Failed to decode or verify token", e);
+        }
+    }
+
+    @Override
+    public boolean isTokenSignatureInvalid(String token, OIDCPublicKey publicKey) {
+        try {
+            String[] parts = token.split("\\.");
+            if (parts.length != 3) {
+                return false;
+            }
+
+            // Prepare data to verify
+            String dataToVerify = parts[0] + "." + parts[1];
+            byte[] signature = Base64.getUrlDecoder().decode(parts[2]);
+
+            // Convert public key components from base64
+            byte[] modulusBytes = Base64.getUrlDecoder().decode(publicKey.getN());
+            byte[] exponentBytes = Base64.getUrlDecoder().decode(publicKey.getE());
+
+            // Create public key
+            BigInteger modulus = new BigInteger(1, modulusBytes);
+            BigInteger exponent = new BigInteger(1, exponentBytes);
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            PublicKey publicKeyObj = factory.generatePublic(spec);
+
+            // Verify signature
+            Signature sig = Signature.getInstance("SHA256withRSA");
+            sig.initVerify(publicKeyObj);
+            sig.update(dataToVerify.getBytes());
+
+            return sig.verify(signature);
+        } catch (Exception e) {
+            log.error("Error verifying token signature", e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/trace/provider/KakaoOIDCProvider.java
+++ b/src/main/java/com/example/trace/provider/KakaoOIDCProvider.java
@@ -86,7 +86,7 @@ public class KakaoOIDCProvider implements OIDCProvider {
         try {
             String[] parts = token.split("\\.");
             if (parts.length != 3) {
-                return false;
+                return true; // Invalid token format
             }
 
             // Prepare data to verify
@@ -109,10 +109,10 @@ public class KakaoOIDCProvider implements OIDCProvider {
             sig.initVerify(publicKeyObj);
             sig.update(dataToVerify.getBytes());
 
-            return sig.verify(signature);
+            return !sig.verify(signature); // Return true if signature is invalid
         } catch (Exception e) {
             log.error("Error verifying token signature", e);
-            return false;
+            return true; // Consider any error as invalid signature
         }
     }
 }

--- a/src/main/java/com/example/trace/provider/OIDCProvider.java
+++ b/src/main/java/com/example/trace/provider/OIDCProvider.java
@@ -1,0 +1,21 @@
+package com.example.trace.provider;
+
+import com.example.trace.models.OIDCDecodePayload;
+import com.example.trace.models.OIDCPublicKey;
+
+public interface OIDCProvider {
+    /**
+     * Extract the kid from the ID token header
+     */
+    String getKidFromUnsignedTokenHeader(String token);
+
+    /**
+     * Verify and decode the ID token payload
+     */
+    OIDCDecodePayload verifyAndDecodeToken(String token, String clientId);
+
+    /**
+     * Verify token signature using provided public key
+     */
+    boolean isTokenSignatureInvalid(String token, OIDCPublicKey publicKey);
+}

--- a/src/main/java/com/example/trace/repository/UserRepository.java
+++ b/src/main/java/com/example/trace/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.trace.repository;
+
+import com.example.trace.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByProviderIdAndProvider(String providerId, String provider);
+}

--- a/src/main/java/com/example/trace/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/trace/service/KakaoOAuthService.java
@@ -1,0 +1,168 @@
+package com.example.trace.service;
+
+import com.example.trace.client.KakaoOAuthClient;
+import com.example.trace.domain.User;
+import com.example.trace.dto.KakaoLoginRequest;
+import com.example.trace.dto.KakaoSignupRequest;
+import com.example.trace.dto.SignupRequiredResponse;
+import com.example.trace.dto.TokenResponse;
+
+import com.example.trace.models.OIDCDecodePayload;
+import com.example.trace.models.OIDCPublicKey;
+import com.example.trace.models.OIDCPublicKeyResponse;
+import com.example.trace.repository.UserRepository;
+import com.example.trace.provider.KakaoOIDCProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOAuthService {
+    private final KakaoOIDCProvider oidcProvider;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    public ResponseEntity<?> processLogin(KakaoLoginRequest request) {
+        try {
+            // 1. Validate ID token
+            OIDCPublicKeyResponse keyResponse = kakaoOAuthClient.getOIDCPublicKey();
+            String kid = oidcProvider.getKidFromUnsignedTokenHeader(request.getIdToken());
+
+            // Find the matching key
+            OIDCPublicKey publicKey = keyResponse.getKeys().stream()
+                    .filter(key -> kid.equals(key.getKid()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("No matching public key found"));
+
+            // Verify signature
+            if (!oidcProvider.isTokenSignatureInvalid(request.getIdToken(), publicKey)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token signature");
+            }
+
+            // Decode and verify payload
+            OIDCDecodePayload payload = oidcProvider.verifyAndDecodeToken(request.getIdToken(), kakaoClientId);
+            
+            // 2. Extract user ID from token payload
+            String userId = payload.getSub();
+            
+            // 3. Check if user exists
+            Optional<User> userOpt = userRepository.findByProviderIdAndProvider(userId, "KAKAO");
+
+            if (userOpt.isPresent()) {
+                // User exists - login process
+                User user = userOpt.get();
+
+                // Generate JWT tokens for your app
+                String accessToken = generateAccessToken(user);
+                String refreshToken = generateRefreshToken(user);
+
+                return ResponseEntity.ok(new TokenResponse(accessToken, refreshToken));
+            } else {
+                // User doesn't exist - store in Redis for signup
+                String redisKey = "signup:" + userId;
+                redisTemplate.opsForValue().set(redisKey, request.getIdToken());
+                redisTemplate.expire(redisKey, 1, TimeUnit.HOURS);
+
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(new SignupRequiredResponse(userId, payload.getEmail(),
+                                payload.getNickname(), payload.getPicture()));
+            }
+
+        } catch (Exception e) {
+            log.error("Error processing login", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Login failed: " + e.getMessage());
+        }
+    }
+
+    public ResponseEntity<?> processSignup(KakaoSignupRequest request) {
+        try {
+            // 1. Get the stored ID token from Redis
+            String userId = extractUserIdFromIdToken(request.getIdToken());
+            String redisKey = "signup:" + userId;
+            String storedIdToken = redisTemplate.opsForValue().get(redisKey);
+
+            if (storedIdToken == null || !storedIdToken.equals(request.getIdToken())) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired signup session");
+            }
+
+            // 2. Validate ID token again
+            OIDCPublicKeyResponse keyResponse = kakaoOAuthClient.getOIDCPublicKey();
+            String kid = oidcProvider.getKidFromUnsignedTokenHeader(request.getIdToken());
+
+            // Find the matching key
+            OIDCPublicKey publicKey = keyResponse.getKeys().stream()
+                    .filter(key -> kid.equals(key.getKid()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("No matching public key found"));
+
+            // Verify signature
+            if (!oidcProvider.isTokenSignatureInvalid(request.getIdToken(), publicKey)) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token signature");
+            }
+
+            // Decode and verify payload
+            OIDCDecodePayload payload = oidcProvider.verifyAndDecodeToken(request.getIdToken(), kakaoClientId);
+
+            // 3. Create user with additional info
+            User newUser = User.builder()
+                    .providerId(payload.getSub())
+                    .provider("KAKAO")
+                    .email(request.getEmail() != null ? request.getEmail() : payload.getEmail())
+                    .nickname(request.getNickname() != null ? request.getNickname() : payload.getNickname())
+                    .profileImage(request.getProfileImage() != null ? request.getProfileImage() : payload.getPicture())
+                    .build();
+
+            userRepository.save(newUser);
+
+            // 4. Generate JWT tokens for your app
+            String accessToken = generateAccessToken(newUser);
+            String refreshToken = generateRefreshToken(newUser);
+
+            // 5. Remove the temporary Redis key
+            redisTemplate.delete(redisKey);
+
+            return ResponseEntity.ok(new TokenResponse(accessToken, refreshToken));
+        } catch (Exception e) {
+            log.error("Error processing signup", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Signup failed: " + e.getMessage());
+        }
+    }
+
+    private String extractUserIdFromIdToken(String idToken) {
+        try {
+            String[] parts = idToken.split("\\.");
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+            JsonNode payloadNode = new ObjectMapper().readTree(payloadJson);
+            return payloadNode.get("sub").asText();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to extract user ID from token", e);
+        }
+    }
+
+    // These methods would use your JWT implementation
+    private String generateAccessToken(User user) {
+        // Implementation depends on your JWT library
+        return "sample_access_token";
+    }
+
+    private String generateRefreshToken(User user) {
+        // Implementation depends on your JWT library
+        return "sample_refresh_token";
+    }
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

카카오 OAuth 로그인 구현 시, 웹 관점으로 구현했다.

1. 앱에서 카카오 로그인 버튼 눌러서 로그인하고 동의
2.카카오 서버가 사용자를 인가 코드 포함된 url로 리다이렉트 시킴
3. 우리 백엔드 서버가 url에서 코드 받아서 카카오 서버로 토큰 요청(리소스 서버에서 사용자 정보 받아오기 위함)
4. 토큰으로 카카오 사용자 정보 가져옴.
5. 사용자 정보 기반 (사용자 id) 우리 서버의 자체 엑세스, 리프레쉬 토큰 생성
6. 앱한테 전달

2번에서 앱 구현에 문제가 생긴다.
앱은 url을 처리하기 위해선 웹뷰를 사용하는 방법 밖에 없는데 
웹뷰를 띄우는 방식이 1. 더 복잡하고 2. 추가적인 보안, 오류 처리 3. 사용자 경험 측면에서 문제점이 발생.

앱은 카카오 sdk 사용 시, 리다이렉션 URL 처리용 인텐트 필터를 설정해주기만 하면 
토큰을 쉽게 받아올 수 있기 때문에, OIDC 방식으로 구현하기로 했다.

## 2. ✨새롭게 변경된 점

앱은 카카오 서버에서 ID TOKEN을 발급 받아 서버에 전달,
서버에서는 ID TOKEN을 검증하는 형식
사용자 정보를 카카오 리소스 서버에 요청할 필요가 없어졌다.
ID TOKEN에 사용자 정보가 다 들어있기 때문.
ID TOKEN은 엑세스 토큰과 달리, 사용자 인증에만 쓰이기 때문에
토큰 자체에 정보량이 많다. 

ID TOKEN을 검증 후, 서버에서 자체 엑세스 토큰 발급하여 앱에 넘겨주면 된다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

외부 API 사용할 때는 기능 구현하기 전에 클라언트랑 좀 더 소통을 먼저 해야할 것 같다.

