### PR TITLE
feat : 감정표현 토글 기능 추가

### DIFF
--- a/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
@@ -37,13 +37,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        log.info("[*] Jwt Filter");
+        log.info("[*] Jwt Filter - Request URI: {}", request.getRequestURI());
 
         try {
             String accessToken = jwtUtil.resolveAccessToken(request);
 
             // accessToken 없이 접근할 경우
             if (accessToken == null) {
+                log.info("[*] No accessToken, proceeding to next filter for URI: {}", request.getRequestURI());
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
                     "/h2-console/**",
                     "/api/v1/h2-console/**",
                         "/api/v1/api/user/*",
-                        "/api/v1/api/posts/*"
+                        "/api/v1/api/posts/*",
+                        "/api/v1//emotion/*"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -39,10 +39,9 @@ public class SecurityConfig {
                 .requestMatchers("/auth/oauth/*",
                     "/api/v1/*",
                     "/h2-console/**",
-                    "/api/v1/h2-console/**",
-                        "/api/v1/api/user/*",
-                        "/api/v1/api/posts/*",
-                        "/api/v1//emotion/*"
+                    "/h2-console/**",
+                    "/api/v1/api/user/*",
+                        "/idtoken"
                 ).permitAll()
                 .anyRequest().authenticated()
             )
@@ -60,16 +59,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
-            "http://localhost:3000",
-            "http://localhost:8080",
-            "https://*.ngrok-free.app"  // ngrok 도메인 허용
-        ));
+        configuration.setAllowedOrigins(Arrays.asList("*"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type"));
         configuration.setAllowCredentials(true);
-        configuration.setExposedHeaders(Arrays.asList("Authorization"));
-
+        
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/com/example/trace/emotion/Emotion.java
+++ b/src/main/java/com/example/trace/emotion/Emotion.java
@@ -1,0 +1,41 @@
+package com.example.trace.emotion;
+
+
+import com.example.trace.post.domain.Post;
+import com.example.trace.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "emotions")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Emotion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "emotion_type", nullable = false)
+    private EmotionType emotionType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/example/trace/emotion/EmotionController.java
+++ b/src/main/java/com/example/trace/emotion/EmotionController.java
@@ -1,0 +1,32 @@
+package com.example.trace.emotion;
+
+import com.example.trace.emotion.dto.EmotionRequest;
+import com.example.trace.emotion.dto.EmotionResponse;
+import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/emotion")
+@RequiredArgsConstructor
+public class EmotionController {
+
+    private final EmotionService emotionServcice;
+    @PostMapping()
+    public EmotionResponse toggleReaction(
+            @RequestBody EmotionRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        User user = principalDetails.getUser();
+        Long postId = request.getPostId();
+        String emotionType = request.getEmotionType();
+
+        EmotionType type = EmotionType.valueOf(emotionType.toUpperCase());
+
+        EmotionResponse emotionResponse = emotionServcice.toggleEmotion(postId,user, type);
+        return emotionResponse;
+    }
+
+}

--- a/src/main/java/com/example/trace/emotion/EmotionRepository.java
+++ b/src/main/java/com/example/trace/emotion/EmotionRepository.java
@@ -1,0 +1,14 @@
+package com.example.trace.emotion;
+
+import com.example.trace.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EmotionRepository extends JpaRepository<Emotion, Long> {
+    Optional<Emotion> findByPostIdAndUserAndEmotionType(Long postId, User user, EmotionType emotionType);
+
+}

--- a/src/main/java/com/example/trace/emotion/EmotionService.java
+++ b/src/main/java/com/example/trace/emotion/EmotionService.java
@@ -1,0 +1,38 @@
+package com.example.trace.emotion;
+
+import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.emotion.dto.EmotionResponse;
+import com.example.trace.post.domain.Post;
+import com.example.trace.post.repository.PostRepository;
+import com.example.trace.user.User;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class EmotionService {
+    EmotionRepository emotionRepository;
+    PostRepository postRepository;
+
+    public EmotionResponse toggleEmotion(Long postId,User user, EmotionType emotionType) {
+        Optional<Emotion> existingEmotion = emotionRepository
+                .findByPostIdAndUserAndEmotionType(postId,user, emotionType);
+        if (existingEmotion.isPresent()) {
+            // 이미 존재하는 감정표현이면 삭제
+            emotionRepository.delete(existingEmotion.get());
+            return new EmotionResponse(false, emotionType.name());
+        } else {
+            // 새로운 감정표현이면 추가
+            Post post = postRepository.findById(postId)
+                    .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+            Emotion emotion = Emotion.builder()
+                    .post(post)
+                    .user(user)
+                    .emotionType(emotionType)
+                    .build();
+            emotionRepository.save(emotion);
+            return new EmotionResponse(true, emotionType.name());
+        }
+    }
+}

--- a/src/main/java/com/example/trace/emotion/EmotionService.java
+++ b/src/main/java/com/example/trace/emotion/EmotionService.java
@@ -6,14 +6,16 @@ import com.example.trace.post.domain.Post;
 import com.example.trace.post.repository.PostRepository;
 import com.example.trace.user.User;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class EmotionService {
-    EmotionRepository emotionRepository;
-    PostRepository postRepository;
+    private final EmotionRepository emotionRepository;
+    private final PostRepository postRepository;
 
     public EmotionResponse toggleEmotion(Long postId,User user, EmotionType emotionType) {
         Optional<Emotion> existingEmotion = emotionRepository

--- a/src/main/java/com/example/trace/emotion/EmotionType.java
+++ b/src/main/java/com/example/trace/emotion/EmotionType.java
@@ -1,0 +1,19 @@
+package com.example.trace.emotion;
+
+public enum EmotionType {
+    WARM("따뜻해요"),
+    GRATEFUL("고마워요"),
+    AWESOME("멋져요"),
+    TOUCHED("감동이에요"),
+    LIKE("좋아요");
+
+    private final String description;
+
+    EmotionType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/example/trace/emotion/dto/EmotionRequest.java
+++ b/src/main/java/com/example/trace/emotion/dto/EmotionRequest.java
@@ -1,0 +1,13 @@
+package com.example.trace.emotion.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmotionRequest {
+    private Long postId;
+    private String emotionType;
+}

--- a/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
+++ b/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
@@ -11,7 +11,6 @@ import lombok.Setter;
 public class EmotionResponse {
     private boolean isAdded;
     private String emotionType;
-    private Long count;
     public EmotionResponse(boolean isAdded, String emotionType) {
         this.isAdded = isAdded;
         this.emotionType = emotionType;

--- a/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
+++ b/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
@@ -1,0 +1,19 @@
+package com.example.trace.emotion.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EmotionResponse {
+    private boolean isAdded;
+    private String emotionType;
+    private Long count;
+    public EmotionResponse(boolean isAdded, String emotionType) {
+        this.isAdded = isAdded;
+        this.emotionType = emotionType;
+    }
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 레포지토리의 쿼리메서드 선언할 때 착각

emotion 이 user 엔티티를 참조하면,
db의 emotion 테이블에 user의 id 가 저장된다는 지식때문에
레포지토리의 쿼리메서드도 findByPostIdAndUserIdAndEmotionType 라고 선언을했다.
userid가 필드명은 아니기 때문에 에러가 떴다.

user 객체 자체를 조건으로 하는 findByPostIdAndUserAndEmotionType 메서드로 다시 선언했다
user 객체 자체가 아닌 user의 id를 조건으로 하기 위해서는 findByPostIdAndUser_IdAndEmotionType 로 선언해야한다.


## 2. ✨새롭게 변경된 점

- 감정표현 토글 기능을 구현했다

- 게시글에 따뜻해요, 고마워요, 멋져요, 감동이에요, 좋아요 등의 감정표현을 누르면 감정표현이 추가된다.

- 이미 추가한 감정표현을 한번 더 누르면 감정표현이 삭제된다.


## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
