### PR TITLE
feat : 게시글 선행 인증 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     
+    // OpenAI API Client
+    implementation 'com.theokanning.openai-gpt3-java:service:0.18.2'
+    
     // H2 데이터베이스 의존성 추가
     runtimeOnly 'com.h2database:h2'
     

--- a/src/main/java/com/example/trace/emotion/Emotion.java
+++ b/src/main/java/com/example/trace/emotion/Emotion.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
@@ -24,6 +26,7 @@ public class Emotion {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @Enumerated(EnumType.STRING)
@@ -32,6 +35,7 @@ public class Emotion {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @CreatedDate

--- a/src/main/java/com/example/trace/gpt/config/OpenAIConfig.java
+++ b/src/main/java/com/example/trace/gpt/config/OpenAIConfig.java
@@ -1,0 +1,22 @@
+package com.example.trace.gpt.config;
+
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import java.time.Duration;
+
+@Configuration
+public class OpenAIConfig {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.timeout:60}")
+    private int timeout;
+
+    @Bean
+    public OpenAiService openAiService() {
+        return new OpenAiService(openaiApiKey, Duration.ofSeconds(timeout));
+    }
+} 

--- a/src/main/java/com/example/trace/gpt/controller/PostVerificationController.java
+++ b/src/main/java/com/example/trace/gpt/controller/PostVerificationController.java
@@ -1,0 +1,24 @@
+package com.example.trace.gpt.controller;
+
+import com.example.trace.gpt.dto.PostVerificationResult;
+import com.example.trace.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/verification")
+@RequiredArgsConstructor
+public class PostVerificationController {
+
+    private final PostService postService;
+    
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostVerificationResult> verifyPost(@PathVariable Long postId) {
+        PostVerificationResult result = postService.verifyPost(postId);
+        return ResponseEntity.ok(result);
+    }
+} 

--- a/src/main/java/com/example/trace/gpt/domain/Verification.java
+++ b/src/main/java/com/example/trace/gpt/domain/Verification.java
@@ -2,10 +2,7 @@ package com.example.trace.gpt.domain;
 
 import com.example.trace.post.domain.Post;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +18,7 @@ import org.hibernate.annotations.OnDeleteAction;
 public class Verification {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/example/trace/gpt/domain/Verification.java
+++ b/src/main/java/com/example/trace/gpt/domain/Verification.java
@@ -1,0 +1,39 @@
+package com.example.trace.gpt.domain;
+
+import com.example.trace.post.domain.Post;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Builder
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Verification {
+
+    @Id
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "post_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Post post;
+
+    private boolean isTextVerified;
+
+    private boolean isImageVerified;
+
+    private String failureReason;
+
+    private String successReason;
+
+}

--- a/src/main/java/com/example/trace/gpt/dto/PostVerificationResult.java
+++ b/src/main/java/com/example/trace/gpt/dto/PostVerificationResult.java
@@ -1,0 +1,35 @@
+package com.example.trace.gpt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostVerificationResult {
+    private boolean textResult;
+    private boolean imageResult;
+    private String successReason;
+    private String failureReason;
+
+
+    public static PostVerificationResult textOnlyFailure(String reason) {
+        return PostVerificationResult.builder()
+                .textResult(false)
+                .imageResult(false)
+                .failureReason(reason)
+                .build();
+    }
+
+
+    public static PostVerificationResult bothFailure(String reason) {
+        return PostVerificationResult.builder()
+                .textResult(false)
+                .imageResult(false)
+                .failureReason(reason)
+                .build();
+    }
+} 

--- a/src/main/java/com/example/trace/gpt/repository/VerificationRepository.java
+++ b/src/main/java/com/example/trace/gpt/repository/VerificationRepository.java
@@ -1,0 +1,10 @@
+package com.example.trace.gpt.repository;
+
+import com.example.trace.gpt.domain.Verification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface VerificationRepository extends JpaRepository<Verification, Long> {
+
+}

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -1,0 +1,8 @@
+package com.example.trace.gpt.service;
+
+import com.example.trace.gpt.dto.PostVerificationResult;
+import com.example.trace.post.domain.Post;
+
+public interface PostVerificationService {
+    PostVerificationResult verifyPost(Post post);
+} 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -1,0 +1,334 @@
+package com.example.trace.gpt.service;
+
+import com.example.trace.gpt.dto.PostVerificationResult;
+import com.example.trace.post.domain.Post;
+import com.example.trace.post.domain.PostImage;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import com.theokanning.openai.service.OpenAiService;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.net.URL;
+import java.util.Base64;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostVerificationServiceImpl implements PostVerificationService {
+
+    private final OpenAiService openAiService;
+    private static final String MODEL = "gpt-4o";
+    
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+    
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public PostVerificationResult verifyPost(Post post) {
+        String content = post.getContent();
+        List<PostImage> images = post.getImages();
+        
+        if (images == null || images.isEmpty()) {
+            // Only text verification is needed
+            return verifyTextOnly(content);
+        } else {
+            // Both text and image verification is needed
+            return verifyTextAndImages(content, images);
+        }
+    }
+    
+    private PostVerificationResult verifyTextOnly(String content) {
+        List<ChatMessage> messages = new ArrayList<>();
+        
+        String systemPrompt = "You are an AI assistant tasked with verifying if the given text describes an act of kindness. " +
+                "Respond in the following format exactly:\n" +
+                "text_result: true/false\n" +
+                "success_reason: [reason for success, only if text_result is true]\n" +
+                "failure_reason: [reason for failure, only if text_result is false]";
+        
+        messages.add(new ChatMessage(ChatMessageRole.SYSTEM.value(), systemPrompt));
+        
+        String userPrompt = "Please verify if the following text describes an act of kindness:\n\n" + content;
+        messages.add(new ChatMessage(ChatMessageRole.USER.value(), userPrompt));
+        
+        ChatCompletionRequest request = ChatCompletionRequest.builder()
+                .model(MODEL)
+                .messages(messages)
+                .build();
+        
+        try {
+            String response = openAiService.createChatCompletion(request).getChoices().get(0).getMessage().getContent();
+            return parseVerificationResponse(response);
+        } catch (Exception e) {
+            log.error("Error verifying text with OpenAI", e);
+            return PostVerificationResult.textOnlyFailure("Failed to verify text: " + e.getMessage());
+        }
+    }
+    
+    private PostVerificationResult verifyTextAndImages(String content, List<PostImage> images) {
+        try {
+            // 직접 OpenAI API 호출하기 위한 요청 구성
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Authorization", "Bearer " + openaiApiKey);
+            
+            // API 요청 본문 구성
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("model", MODEL);
+            requestBody.put("max_tokens", 500);
+            
+            // 메시지 배열 구성
+            List<Map<String, Object>> messages = new ArrayList<>();
+            
+            // 시스템 메시지 추가
+            Map<String, Object> systemMessage = new HashMap<>();
+            systemMessage.put("role", "system");
+            systemMessage.put("content", "You are an AI assistant tasked with verifying if the given text describes an act of kindness " +
+                    "and if the provided images properly describe the text and relate to acts of kindness. " +
+                    "Respond in the following format exactly:\n" +
+                    "text_result: true/false\n" +
+                    "image_result: true/false\n" +
+                    "success_reason: [reason for success, only if any result is true]\n" +
+                    "failure_reason: [reason for failure, only if any result is false]");
+            messages.add(systemMessage);
+            
+            // 유저 메시지 추가
+            Map<String, Object> userMessage = new HashMap<>();
+            userMessage.put("role", "user");
+            
+            // 유저 메시지의 콘텐츠 구성 (배열)
+            List<Map<String, Object>> contentItems = new ArrayList<>();
+            
+            // 텍스트 콘텐츠 추가
+            Map<String, Object> textContent = new HashMap<>();
+            textContent.put("type", "text");
+            textContent.put("text", "Please verify the following:\n\n" +
+                    "1. Does the text describe an act of kindness?\n" +
+                    "2. Do the images properly describe the text and relate to acts of kindness?\n\n" +
+                    "Text: " + content);
+            contentItems.add(textContent);
+            
+            // 이미지 추가
+            for (PostImage image : images) {
+                try {
+                    String base64Image = downloadAndEncodeImage(image.getImageUrl());
+                    if (base64Image != null) {
+                        Map<String, Object> imageContent = new HashMap<>();
+                        imageContent.put("type", "image_url");
+                        
+                        Map<String, String> imageUrl = new HashMap<>();
+                        imageUrl.put("url", "data:image/jpeg;base64," + base64Image);
+                        log.info("Image URL length: {}", base64Image.length());
+                        
+                        imageContent.put("image_url", imageUrl);
+                        contentItems.add(imageContent);
+                    } else {
+                        log.warn("Failed to process image: " + image.getImageUrl());
+                    }
+                } catch (Exception e) {
+                    log.error("Error processing image: " + image.getImageUrl(), e);
+                }
+            }
+            
+            userMessage.put("content", contentItems);
+            messages.add(userMessage);
+            
+            requestBody.put("messages", messages);
+            
+            // API 요청 보내기
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+            
+            // 디버깅을 위해 요청 내용 로깅 (이미지 데이터는 길이만 로깅)
+            try {
+                String debugRequestBody = objectMapper.writeValueAsString(requestBody);
+                
+                // 실제 base64 이미지 데이터는 너무 길어서 길이만 로깅
+                if (debugRequestBody.contains("\"url\":\"data:image/jpeg;base64,")) {
+                    debugRequestBody = debugRequestBody.replaceAll(
+                        "(\"url\":\"data:image/jpeg;base64,)[^\"]+", 
+                        "$1...[BASE64_DATA_LENGTH: " + 
+                        debugRequestBody.split("\"url\":\"data:image/jpeg;base64,")[1].split("\"")[0].length() + 
+                        "]..."
+                    );
+                }
+                
+                log.info("OpenAI API Request: {}", debugRequestBody);
+            } catch (Exception e) {
+                log.warn("Failed to log request body", e);
+            }
+            
+            ResponseEntity<String> responseEntity = restTemplate.postForEntity(
+                    "https://api.openai.com/v1/chat/completions", 
+                    request, 
+                    String.class);
+            
+            // 응답 로깅
+            log.info("OpenAI API Response Status: {}", responseEntity.getStatusCode());
+            
+            // 응답 파싱 
+            Map<String, Object> responseMap = objectMapper.readValue(responseEntity.getBody(), Map.class);
+            
+            // 에러 체크
+            if (responseMap.containsKey("error")) {
+                Map<String, Object> error = (Map<String, Object>) responseMap.get("error");
+                String errorMessage = (String) error.get("message");
+                log.error("OpenAI API Error: {}", errorMessage);
+                return PostVerificationResult.bothFailure("OpenAI API Error: " + errorMessage);
+            }
+            
+            List<Map<String, Object>> choices = (List<Map<String, Object>>) responseMap.get("choices");
+            Map<String, Object> firstChoice = choices.get(0);
+            Map<String, Object> message = (Map<String, Object>) firstChoice.get("message");
+            String responseContent = (String) message.get("content");
+            
+            return parseVerificationResponse(responseContent);
+            
+        } catch (Exception e) {
+            log.error("Error verifying text and images with OpenAI", e);
+            return PostVerificationResult.bothFailure("Failed to verify content: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Downloads an image from a URL and encodes it as base64
+     */
+    private String downloadAndEncodeImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.trim().isEmpty()) {
+            log.error("Empty or null image URL");
+            return null;
+        }
+        
+        // URL 형식 검증
+        if (!imageUrl.startsWith("http://") && !imageUrl.startsWith("https://")) {
+            log.error("Invalid image URL format: {}", imageUrl);
+            return null;
+        }
+        
+        try {
+            URL url = new URL(imageUrl);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.setDoInput(true);
+            connection.setConnectTimeout(10000); // 10초 타임아웃
+            connection.setReadTimeout(10000);  // 10초 타임아웃
+            connection.connect();
+            
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                log.error("Failed to connect to image URL: " + imageUrl + ", status: " + connection.getResponseCode());
+                return null;
+            }
+            
+            // 컨텐츠 타입 확인 (이미지인지)
+            String contentType = connection.getContentType();
+            if (contentType == null || !contentType.startsWith("image/")) {
+                log.error("URL does not point to an image. Content-Type: {}", contentType);
+                return null;
+            }
+            
+            // 이미지 크기 확인 (너무 크면 실패할 수 있음)
+            int contentLength = connection.getContentLength();
+            if (contentLength > 20 * 1024 * 1024) { // 20MB 제한
+                log.error("Image too large: {} bytes", contentLength);
+                return null;
+            }
+            
+            try (InputStream in = connection.getInputStream()) {
+                // 바이트 배열로 직접 읽기
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, bytesRead);
+                }
+                
+                byte[] imageBytes = out.toByteArray();
+                if (imageBytes.length == 0) {
+                    log.error("Downloaded empty image from URL: " + imageUrl);
+                    return null;
+                }
+                
+                // 이미지 크기가 적절한지 확인 (너무 크면 API 요청이 실패할 수 있음)
+                if (imageBytes.length > 20 * 1024 * 1024) { // 20MB 제한
+                    log.error("Image too large after download: {} bytes", imageBytes.length);
+                    return null;
+                }
+                
+                String base64 = Base64.getEncoder().encodeToString(imageBytes);
+                log.info("Successfully encoded image from URL: {}, size: {} bytes, base64 length: {}", 
+                        imageUrl, imageBytes.length, base64.length());
+                return base64;
+            }
+        } catch (IOException e) {
+            log.error("Failed to download or encode image: " + imageUrl, e);
+            return null;
+        }
+    }
+    
+    private PostVerificationResult parseVerificationResponse(String response) {
+        boolean textResult = false;
+        boolean imageResult = false;
+        String successReason = null;
+        String failureReason = null;
+        
+        // Extract text_result
+        Pattern textPattern = Pattern.compile("text_result\\s*:\\s*(true|false)", Pattern.CASE_INSENSITIVE);
+        Matcher textMatcher = textPattern.matcher(response);
+        if (textMatcher.find()) {
+            textResult = "true".equalsIgnoreCase(textMatcher.group(1));
+        }
+        
+        // Extract image_result
+        Pattern imagePattern = Pattern.compile("image_result\\s*:\\s*(true|false)", Pattern.CASE_INSENSITIVE);
+        Matcher imageMatcher = imagePattern.matcher(response);
+        if (imageMatcher.find()) {
+            imageResult = "true".equalsIgnoreCase(imageMatcher.group(1));
+        }
+        
+        // Extract success_reason
+        Pattern successPattern = Pattern.compile("success_reason\\s*:\\s*(.+?)(?=\\n|$)", Pattern.CASE_INSENSITIVE);
+        Matcher successMatcher = successPattern.matcher(response);
+        if (successMatcher.find()) {
+            successReason = successMatcher.group(1).trim();
+        }
+        
+        // Extract failure_reason
+        Pattern failurePattern = Pattern.compile("failure_reason\\s*:\\s*(.+?)(?=\\n|$)", Pattern.CASE_INSENSITIVE);
+        Matcher failureMatcher = failurePattern.matcher(response);
+        if (failureMatcher.find()) {
+            failureReason = failureMatcher.group(1).trim();
+        }
+        
+        return PostVerificationResult.builder()
+                .textResult(textResult)
+                .imageResult(imageResult)
+                .successReason(successReason)
+                .failureReason(failureReason)
+                .build();
+    }
+} 

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -1,6 +1,8 @@
 package com.example.trace.post.domain;
 
 import com.example.trace.user.User;
+import com.example.trace.gpt.domain.Verification;
+
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +12,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
+
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -49,6 +52,12 @@ public class Post {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    @OneToOne
+    @JoinColumn(name = "verification_id")
+    private Verification verification;
+
+
     
     public void addImage(PostImage image) {
         this.images.add(image);

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
@@ -33,6 +35,7 @@ public class Post {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Builder.Default

--- a/src/main/java/com/example/trace/post/domain/PostImage.java
+++ b/src/main/java/com/example/trace/post/domain/PostImage.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -23,6 +25,7 @@ public class PostImage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/trace/post/service/PostService.java
+++ b/src/main/java/com/example/trace/post/service/PostService.java
@@ -1,5 +1,6 @@
 package com.example.trace.post.service;
 
+import com.example.trace.gpt.dto.PostVerificationResult;
 import com.example.trace.post.dto.PostUpdateDto;
 import com.example.trace.post.dto.PostCreateDto;
 import com.example.trace.post.dto.PostDto;
@@ -16,4 +17,6 @@ public interface PostService {
     PostDto updatePost(Long id, PostUpdateDto postUpdateDto,Long userId);
     
     void deletePost(Long id, Long userId);
+    
+    PostVerificationResult verifyPost(Long postId);
 } 

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.trace.post.service;
 
+import com.example.trace.gpt.dto.PostVerificationResult;
+import com.example.trace.gpt.service.PostVerificationService;
 import com.example.trace.user.User;
 import com.example.trace.file.FileType;
 import com.example.trace.file.S3UploadService;
@@ -26,6 +28,7 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final S3UploadService s3UploadService;
+    private final PostVerificationService postVerificationService;
     
     private static final int MAX_IMAGES = 5;
 
@@ -120,6 +123,15 @@ public class PostServiceImpl implements PostService {
         }
         
         postRepository.delete(post);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PostVerificationResult verifyPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        
+        return postVerificationService.verifyPost(post);
     }
 
 } 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### DB 테이블 생성된 후 수정

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

@GeneratedValue를 깜빡하고 프로젝트를 실행했는데 DB 스키마가 업데이트 됐다. 
스키마에 컬럼이 추가된 후에는 컬럼에 대한 수정이 되지 않아서,
Verification 엔티티를 수정하여 @GeneratedValue를 추가했음에도 ,
id 컬럼에 대한 자동생성이 되지 않아, null 값이 들어가게됐다. 

ALTER TABLE VERIFICATION ALTER COLUMN ID BIGINT AUTO_INCREMENT;
h2 콘솔에 sql 문을 입력하여 데이터 베이스의 스키마를 직접 수정하였다. 

### 라이브러리 소스와 바이트코드 불일치 오류

openai 클라이언트 라이브러리의 chatmessage 클래스에
library source does not match the bytecode for class ChatMessage" 오류가 떴다. 
해결방법 찾기가 어려워서 resttemplate으로 직접 openai api 에 요청을 하는 방법을 사용했다.
그 후에 openai api 라이브러리를 사용해서 빌드를 돌려보니 딱히 오류가 안나와서 verifyTextOnly 메서드에서는 
openai api 라이브러리를 직접 사용하여 구현하였다. 


## 2. ✨새롭게 변경된 점

- 게시글에 대한 선행 인증 기능

- 텍스트와 이미지 각각에 대한 선행 인증 실행

- 게시글에 인증 정보 추가

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
