### PR TITLE
chore : CI/CD 도입 완료

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,52 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Get current time
+        uses: josStorer/get-current-time@v2.0.2
+        id: current-time
+        with:
+          format: YYYY-MM-DDTHH-mm-ss
+          utcOffset: "+09:00"
+
+      - name: Set artifact
+        run: echo "artifact=$(ls ./build/libs)" >> $GITHUB_ENV
+
+      - name: Beanstalk Deploy
+        uses: einaregilsson/beanstalk-deploy@v20
+        with:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+          SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
+          SPRING_DATA_REDIS_HOST: ${{ secrets.SPRING_DATA_REDIS_HOST }}
+          SPRING_DATA_REDIS_PORT: ${{ secrets.SPRING_DATA_REDIS_PORT }}
+          application_name: Trace111
+          environment_name: Trace111-env
+          version_label: github-action-${{steps.current-time.outputs.formattedTime}}
+          region: ap-northeast-2
+          deployment_package: ./build/libs/${{env.artifact}}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,15 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
-      SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-      SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
-      SPRING_DATA_REDIS_HOST: ${{ secrets.SPRING_DATA_REDIS_HOST }}
-      SPRING_DATA_REDIS_PORT: ${{ secrets.SPRING_DATA_REDIS_PORT }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,7 @@ name: CI/CD
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-#테스트
+#테스트2
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,7 @@ name: CI/CD
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-#테스트2
+#테스트5
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -43,9 +43,6 @@ jobs:
 
       - name: Beanstalk Deploy
         uses: einaregilsson/beanstalk-deploy@v20
-        env:
-          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
-          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,8 +30,10 @@ jobs:
           utcOffset: "+09:00"
 
       - name: Set artifact
-        run: echo "artifact=$(ls ./build/libs)" >> $GITHUB_ENV
-
+        run: |
+          echo 'artifact<<EOF' >> $GITHUB_ENV
+          ls ./build/libs >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Beanstalk Deploy
         uses: einaregilsson/beanstalk-deploy@v20
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-#테스트
+#테스트1
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -4,7 +4,7 @@ name: CI/CD
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-#테스트5
+#테스트6
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-
+#테스트
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ chore/jiseob/#39 ]
+    branches: [ develop ]
 #테스트6
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ chore/jiseob/#39 ]
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
+      SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
+      SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
+      SPRING_DATA_REDIS_HOST: ${{ secrets.SPRING_DATA_REDIS_HOST }}
+      SPRING_DATA_REDIS_PORT: ${{ secrets.SPRING_DATA_REDIS_PORT }}
 
     steps:
       - uses: actions/checkout@v3
@@ -37,16 +46,8 @@ jobs:
       - name: Beanstalk Deploy
         uses: einaregilsson/beanstalk-deploy@v20
         with:
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          SPRING_DATASOURCE_PASSWORD: ${{ secrets.SPRING_DATASOURCE_PASSWORD }}
-          SPRING_DATASOURCE_URL: ${{ secrets.SPRING_DATASOURCE_URL }}
-          SPRING_DATASOURCE_USERNAME: ${{ secrets.SPRING_DATASOURCE_USERNAME }}
-          SPRING_DATA_REDIS_HOST: ${{ secrets.SPRING_DATA_REDIS_HOST }}
-          SPRING_DATA_REDIS_PORT: ${{ secrets.SPRING_DATA_REDIS_PORT }}
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
           application_name: Trace111
           environment_name: Trace111-env
           version_label: github-action-${{steps.current-time.outputs.formattedTime}}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,9 +1,10 @@
+
 name: CI/CD
 
 on:
   push:
     branches: [ chore/jiseob/#39 ]
-#테스트1
+#테스트
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,11 +41,20 @@ jobs:
 
       - name: Set artifact
         run: |
-          echo 'artifact<<EOF' >> $GITHUB_ENV
-          ls ./build/libs >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
+          ARTIFACT_NAME=$(ls ./build/libs | grep -v "plain" | head -n 1)
+          echo "artifact=$ARTIFACT_NAME" >> $GITHUB_ENV
+
+      - name: Debug
+        run: |
+          echo "Artifact: ${{ env.artifact }}"
+          echo "Access key exists: ${{ secrets.AWS_ACCESS_KEY != '' }}"
+          echo "Secret key exists: ${{ secrets.AWS_SECRET_KEY != '' }}"
+
       - name: Beanstalk Deploy
         uses: einaregilsson/beanstalk-deploy@v20
+        env:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_key: ${{ secrets.AWS_SECRET_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ java {
 	}
 }
 
+jar{
+	enabled = false
+}
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/src/main/java/com/example/trace/auth/config/RedisConfig.java
+++ b/src/main/java/com/example/trace/auth/config/RedisConfig.java
@@ -23,10 +23,10 @@ import java.time.Duration;
 @EnableRedisRepositories
 @EnableCaching
 public class RedisConfig {
-    @Value("${data.redis.host}")
+    @Value("${SPRING_DATA_REDIS_HOST}")
     private String redisHost;
 
-    @Value("${data.redis.port}")
+    @Value("${SPRING_DATA_REDIS_PORT}")
     private int redisPort;
 
     @Bean

--- a/src/main/java/com/example/trace/file/S3Config.java
+++ b/src/main/java/com/example/trace/file/S3Config.java
@@ -11,10 +11,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-    @Value("${cloud.aws.credentials.access-key}")
+    @Value("${AWS_ACCESS_KEY}")
     private String accessKey;
 
-    @Value("${cloud.aws.credentials.secret-key}")
+    @Value("${AWS_SECRET_KEY}")
     private String secretKey;
 
     @Value("${cloud.aws.region.static}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,36 @@ spring:
     name: Trace
   profiles:
     active: local
-  config:
-    import: application-secret.yml
+
+# AWS S3 설정
+cloud:
+  aws:
+    s3:
+      bucket: wap-trace-bucket
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
+
+# SpringDoc 설정 추가
+springdoc:
+  version: '1.0'
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  show-actuator: false
+  paths-to-match:
+    - /token/**
+    - /auth/**
+
+
 
   # OAuth2 클라이언트 설정 - API 키 관리, 외부에 노출되면 안 됨
 oauth2:
@@ -24,11 +52,6 @@ jwt:
     access-expiration-time: 3600000  # 1시간
     refresh-expiration-time: 604800000  # 7일
 
-  # Redis 설정
-data:
-  redis:
-    host: localhost
-    port: 6379
 
   # 로깅 설정
 logging:
@@ -47,6 +70,7 @@ spring:
   config:
     activate:
       on-profile: dev
+
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -85,11 +109,6 @@ server:
   tomcat:
     basedir: ./temp  # Custom temp directory for Tomcat
 
-
-
-
-
-# 커스텀 애플리케이션 설정
 
 ---
 # 개발 환경 설정
@@ -137,20 +156,4 @@ server:
     include-exception: false
   tomcat:
     basedir: ./temp  # Custom temp directory for Tomcat
-
-# SpringDoc 설정 추가
-springdoc:
-  version: '1.0'
-  api-docs:
-    path: /api-docs
-  swagger-ui:
-    path: /swagger-ui.html
-    tags-sorter: alpha
-    operations-sorter: alpha
-  default-consumes-media-type: application/json
-  default-produces-media-type: application/json
-  show-actuator: false
-  paths-to-match:
-    - /token/**
-    - /auth/**
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local
+    active: dev
 
 # AWS S3 설정
 cloud:

--- a/src/test/java/com/example/trace/TraceApplicationTests.java
+++ b/src/test/java/com/example/trace/TraceApplicationTests.java
@@ -2,12 +2,48 @@ package com.example.trace;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.test.context.TestPropertySource;
+
+import com.example.trace.auth.Util.JwtUtil;
+import com.example.trace.auth.Util.RedisUtil;
+import com.example.trace.auth.config.SecurityConfig;
+import com.example.trace.auth.repository.UserRepository;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+		"spring.cloud.openfeign.enabled=false",
+		"spring.data.redis.host=localhost",
+		"spring.data.redis.port=6379",
+		"spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
+})
 class TraceApplicationTests {
+
+	@MockBean
+	private JwtUtil jwtUtil;
+
+	@MockBean
+	private RedisUtil redisUtil;
+
+	@MockBean
+	private UserRepository userRepository;
+
+	@MockBean
+	private SecurityConfig securityConfig;
 
 	@Test
 	void contextLoads() {
+		// Basic test to verify the application context loads successfully
 	}
 
+	@Configuration
+	static class TestSecurityConfig {
+		@Bean
+		public WebSecurityCustomizer webSecurityCustomizer() {
+			return web -> web.ignoring().requestMatchers("/**");
+		}
+	}
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 테스트 애플리케이션 빌드 오류

테스트 파일에 JwtUtil,RedisUtil,UserRepository,SecurityConfig을 모킹하여 모의 객체로 구현하여 해결

### 깃허브 액션을 통해 일라스틱 빈스토크에 배포가 안되는 문제 발생

일라스틱 빈스토크에 직접 빌드 파일 업로드할 때는 내가 AWS의 루트 사용자라서 가능했던 것.

깃허브 레포에서 aws 엑세스 키를 설정해야함.

깃허브 액션에 대한 IAM 설정을 한 뒤, AWS 엑세스 키와 시크릿 키를 발급받아야한다.

발급 받은 키들은 환경 변수에 지정해두어야한다. 배포할 때 쓰이는 키라고 보면 된다.

또한 헷갈릴 수 있는데 빈스토크 환경 변수에 저장해놓은 AWS 엑세스 키와 시크릿 키는 앱 자체에서 S3에 파일을 올릴 때, 필요한 키 들이다.


## 2. ✨새롭게 변경된 점

- develop 브랜치에 푸쉬하면, 배포 환경에 자동으로 적용된다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

깃허브액션, 일라스틱 빈스토크 , ec2 등 시스템 아키텍처에 대한 배경지식이 많이 부족해서
나중에 각잡고 공부해보고 싶다.
