### PR TITLE
refactor : 게시글 api 개선

### DIFF
--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                     "/api/v1/api/user/*",
                     "/idtoken",
                     "/token/refresh",
+                    "/token/expiration",
                     // Swagger UI v3 (OpenAPI)
                     "/v3/api-docs/**",
                     "/api-docs/**",

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -62,8 +62,8 @@ public class PostController {
             @PathVariable Long id,
             @Valid @RequestBody PostUpdateDto postUpdateDto,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Long userId = principalDetails.getUser().getId();
-        PostDto updatedPost = postService.updatePost(id, postUpdateDto, userId);
+        String providerId = principalDetails.getUser().getProviderId();
+        PostDto updatedPost = postService.updatePost(id, postUpdateDto, providerId);
         return ResponseEntity.ok(updatedPost);
     }
 
@@ -72,8 +72,8 @@ public class PostController {
             @PathVariable Long id,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        Long userId = user.getId();
-        postService.deletePost(id, userId);
+        String providerId = user.getProviderId();
+        postService.deletePost(id, providerId);
         return ResponseEntity.noContent().build(); // 삭제 시엔 204 응답
     }
 } 

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -6,6 +6,10 @@ import com.example.trace.post.dto.PostCreateDto;
 import com.example.trace.post.dto.PostDto;
 import com.example.trace.post.dto.PostUpdateDto;
 import com.example.trace.post.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,11 +24,17 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/posts")
 @RequiredArgsConstructor
+@Tag(name = "게시글 API", description = "게시글 관련 API")
 public class PostController {
 
     private final PostService postService;
 
+
     @PostMapping
+    @Operation(summary = "게시글 생성", description = "게시글 생성 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "게시글 생성 성공"),
+    })
     public ResponseEntity<PostDto> createPostWithPictures(
             @Valid @RequestPart("request") PostCreateDto postCreateDto,
             @RequestPart(value = "imageFile", required = false) List<MultipartFile> imageFiles,

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -29,7 +29,6 @@ public class PostController {
             @Valid @RequestPart("request") PostCreateDto postCreateDto,
             @RequestPart(value = "imageFile", required = false) List<MultipartFile> imageFiles,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Long userId = principalDetails.getUser().getId();
         String ProviderId = principalDetails.getUser().getProviderId();
 
         if (imageFiles != null && !imageFiles.isEmpty()) {
@@ -38,7 +37,7 @@ public class PostController {
             postCreateDto.setImageFiles(imageFiles.subList(0, maxImages));
         }
 
-        PostDto createdPost = postService.createPostWithPictures(postCreateDto, userId, ProviderId);
+        PostDto createdPost = postService.createPostWithPictures(postCreateDto, ProviderId);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdPost);
     }
 

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -37,7 +37,7 @@ public class Post {
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "provider_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -30,6 +30,10 @@ public class Post {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "post_type", nullable = false)
+    private PostType postType;
+
     @Column(nullable = false)
     private String title;
 

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -72,4 +72,8 @@ public class Post {
         this.images.add(image);
         image.setPost(this);
     }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -34,6 +34,9 @@ public class Post {
     @Column(name = "post_type", nullable = false)
     private PostType postType;
 
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
     @Column(nullable = false)
     private String title;
 
@@ -60,6 +63,8 @@ public class Post {
     @OneToOne
     @JoinColumn(name = "verification_id")
     private Verification verification;
+
+
 
 
 

--- a/src/main/java/com/example/trace/post/domain/PostType.java
+++ b/src/main/java/com/example/trace/post/domain/PostType.java
@@ -1,0 +1,16 @@
+package com.example.trace.post.domain;
+
+public enum PostType {
+    ALL("전체"),
+    FREE("자유"),
+    GOOD_DEED("선행"),
+    MISSION("미션");
+
+    private final String type;
+    PostType(String type){
+        this.type = type;
+    }
+    public String getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/example/trace/post/dto/PostCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostCreateDto.java
@@ -1,5 +1,6 @@
 package com.example.trace.post.dto;
 
+import com.example.trace.post.domain.PostType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,9 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PostCreateDto {
+
+    @NotBlank(message = "게시글 유형을 선택해주세요")
+    private String postType;
     
     @NotBlank(message = "제목을 입력해주세요")
     private String title;

--- a/src/main/java/com/example/trace/post/dto/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostDto.java
@@ -20,7 +20,7 @@ public class PostDto {
     private Long id;
     private String title;
     private String content;
-    private Long userId;
+    private String providerId;
     private String nickname;
     private List<String> imageUrls;
     private LocalDateTime createdAt;
@@ -37,7 +37,7 @@ public class PostDto {
                 .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .userId(post.getUser().getId())
+                .providerId(post.getUser().getProviderId())
                 .nickname(post.getUser().getNickname())
                 .imageUrls(imageUrls)
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/com/example/trace/post/dto/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostDto.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class PostDto {
     private Long id;
+    private String postType;
     private String title;
     private String content;
     private String providerId;
@@ -35,6 +36,7 @@ public class PostDto {
                 
         return PostDto.builder()
                 .id(post.getId())
+                .postType(post.getPostType().name())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .providerId(post.getUser().getProviderId())

--- a/src/main/java/com/example/trace/post/dto/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostDto.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 public class PostDto {
     private Long id;
     private String postType;
+    private Long viewCount;
     private String title;
     private String content;
     private String providerId;
@@ -37,6 +38,7 @@ public class PostDto {
         return PostDto.builder()
                 .id(post.getId())
                 .postType(post.getPostType().name())
+                .viewCount(post.getViewCount())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .providerId(post.getUser().getProviderId())

--- a/src/main/java/com/example/trace/post/service/PostService.java
+++ b/src/main/java/com/example/trace/post/service/PostService.java
@@ -14,9 +14,9 @@ public interface PostService {
 
     PostDto getPostById(Long id);
 
-    PostDto updatePost(Long id, PostUpdateDto postUpdateDto,Long userId);
+    PostDto updatePost(Long id, PostUpdateDto postUpdateDto,String providerId);
     
-    void deletePost(Long id, Long userId);
+    void deletePost(Long id, String providerId);
     
     PostVerificationResult verifyPost(Long postId);
 } 

--- a/src/main/java/com/example/trace/post/service/PostService.java
+++ b/src/main/java/com/example/trace/post/service/PostService.java
@@ -10,7 +10,7 @@ public interface PostService {
     
     PostDto createPost(PostCreateDto postCreateDto,Long userId);
 
-    PostDto createPostWithPictures(PostCreateDto postCreateDto,Long userId, String ProviderId);
+    PostDto createPostWithPictures(PostCreateDto postCreateDto, String ProviderId);
 
     PostDto getPostById(Long id);
 

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -102,11 +102,11 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public PostDto updatePost(Long id, PostUpdateDto postUpdateDto, Long userId) {
+    public PostDto updatePost(Long id, PostUpdateDto postUpdateDto, String providerId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
         
-        if (!post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getProviderId().equals(providerId)) {
             throw new AccessDeniedException("게시글을 수정할 권한이 없습니다.");
         }
         
@@ -119,11 +119,11 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public void deletePost(Long id, Long userId) {
+    public void deletePost(Long id, String providerId) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
         
-        if (!post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getProviderId().equals(providerId)) {
             throw new AccessDeniedException("게시글을 삭제할 권한이 없습니다.");
         }
         

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -59,6 +59,7 @@ public class PostServiceImpl implements PostService {
 
         Post post = Post.builder()
                 .postType(PostType.valueOf(postCreateDto.getPostType()))
+                .viewCount(0L)
                 .title(postCreateDto.getTitle())
                 .content(postCreateDto.getContent())
                 .user(user)
@@ -95,6 +96,7 @@ public class PostServiceImpl implements PostService {
     public PostDto getPostById(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("게시글을 찾을 수 없습니다."));
+        post.incrementViewCount();
         return PostDto.fromEntity(post);
     }
 

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -52,8 +52,8 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public PostDto createPostWithPictures(PostCreateDto postCreateDto, Long userId, String ProviderId) {
-        User user = userRepository.findById(userId)
+    public PostDto createPostWithPictures(PostCreateDto postCreateDto, String ProviderId) {
+        User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
         Post post = Post.builder()

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.trace.post.service;
 
 import com.example.trace.gpt.dto.PostVerificationResult;
 import com.example.trace.gpt.service.PostVerificationService;
+import com.example.trace.post.domain.PostType;
 import com.example.trace.user.User;
 import com.example.trace.file.FileType;
 import com.example.trace.file.S3UploadService;
@@ -57,6 +58,7 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
         Post post = Post.builder()
+                .postType(PostType.valueOf(postCreateDto.getPostType()))
                 .title(postCreateDto.getTitle())
                 .content(postCreateDto.getContent())
                 .user(user)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,6 +117,11 @@ spring:
     activate:
       on-profile: local
 
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:db/data.sql
+
   # H2 데이터베이스 설정
   datasource:
     url: jdbc:h2:file:./data/tracedb
@@ -134,7 +139,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 게시글 조회에 userId가 회원가입시 받는 userId와 다른 문제

원래 카카오에서 받은 카카오 id로 user를 식별하기 위해, 
비회원이 로그인 시, 회원가입을 위한 정보로 본인 카카오 id(provideId)를 보내줬다. 
providerId를 전체 프로젝트에서 사용자 식별자로 사용하고 있다.

근데 게시글 생성한 뒤, postdto 를 보낼 때, userId 필드에 user의 pk를 넣어줬기 때문에,
게시글 조회 시, 사용자의 식별자가 달라지는 문제가 생긴다. 
그러면 사용자의 식별자(providerId)와 사용자가 생성한 게시글의 사용자 식별자(user의 pk)가 다르므로,
수정과 삭제가 어려워진다. 

따라서 게시글 생성 뒤, postdto를 보낼 때, providerId 필드에 providerId를 넣어서 게시글 조회 시, 사용자의 식별자를 일치시켜주었다. 

덧붙여, 수정과 삭제에도 user의 pk로 비교하고 있었으므로 providerId끼리 비교할 수 있도록 수정해두었다.



## 2. ✨새롭게 변경된 점

- 게시글 생성 시, postType을 설정할 수 있다. (ALL : "전체", FREE : "자유", GOODEED : "선행", MISSION : "미션")

- 게시글 필드에 viewCount를 추가하여, 조회 시, 1씩 증가하는 기능을 추가하였다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
