### PR TITLE
feat : 댓글 기능 추가

### DIFF
--- a/src/main/java/com/example/trace/auth/dto/request/KakaoSignupRequest.java
+++ b/src/main/java/com/example/trace/auth/dto/request/KakaoSignupRequest.java
@@ -28,7 +28,7 @@ public class KakaoSignupRequest {
     @Schema(description = "email 설정", example = "exampl@example.com")
     private String email;
 
-    @Schema(description = "회원가입 정보에서 받은 기본 프사", example = "https://example.com/profile.jpg")
+    @Schema(description = "프로필 이미지 url", example = "https://wap-trace-bucket.s3.ap-northeast-2.amazonaws.com/profile/ab54b37b-d46_1.png_4237792414")
     private String profileImageUrl; // 프로필 이미지 URL
     
     // 프로필 이미지 파일 업로드를 위한 필드 (직렬화에서 제외)

--- a/src/main/java/com/example/trace/global/errorcode/PostErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/PostErrorCode.java
@@ -11,7 +11,10 @@ public enum PostErrorCode implements ErrorCode{
     POST_IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "게시글 이미지 업로드에 실패했습니다."),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "게시글 수정 권한이 없습니다."),
-    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다.")
+    POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "게시글 삭제 권한이 없습니다."),
+    CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "내용이 비어있습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "댓글 삭제 권한이 없습니다."),
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/trace/gpt/dto/PostVerificationResult.java
+++ b/src/main/java/com/example/trace/gpt/dto/PostVerificationResult.java
@@ -16,9 +16,9 @@ public class PostVerificationResult {
     private boolean textResult;
     @Schema(description = "이미지 인증 결과", example = "true")
     private boolean imageResult;
-    @Schema(description = "인증 성공 이유", example = "텍스트 인증 성공")
+    @Schema(description = "인증 성공 이유", example = "텍스트가 선행에 대한 설명이고, 이미지는 텍스트와 관련되있으며 선행과 관련된 이미지입니다.")
     private String successReason;
-    @Schema(description = "인증 실패 이유", example = "텍스트 인증 실패")
+    @Schema(description = "인증 실패 이유", example = "null")
     private String failureReason;
 
 

--- a/src/main/java/com/example/trace/post/controller/CommentController.java
+++ b/src/main/java/com/example/trace/post/controller/CommentController.java
@@ -1,0 +1,78 @@
+package com.example.trace.post.controller;
+
+import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.post.dto.comment.CommentCreateDto;
+import com.example.trace.post.dto.comment.CommentDto;
+import com.example.trace.post.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+@Tag(name = "Comment", description = "댓글 API")
+public class CommentController {
+    private final CommentService commentService;
+
+
+
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "댓글 작성 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CommentDto.class)
+            )
+    )
+    @PostMapping("/{postId}")
+    public ResponseEntity<?> addComment(
+            @PathVariable Long postId,
+            @RequestBody CommentCreateDto commentCreateDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String providerId = principalDetails.getUser().getProviderId();
+        return ResponseEntity.ok(commentService.addComment(postId, commentCreateDto, providerId));
+    }
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponse(
+            responseCode = "204",
+            description = "댓글 삭제 성공"
+    )
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String providerId = principalDetails.getUser().getProviderId();
+        commentService.deleteComment(commentId, providerId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "대댓글 작성", description = "게시글에 대댓글을 작성합니다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "대댓글 작성 성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CommentDto.class)
+            )
+    )
+    @PostMapping("/{postId}/{commentId}")
+    public ResponseEntity<?> addChildrenComment(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody CommentCreateDto commentCreateDto,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String providerId = principalDetails.getUser().getProviderId();
+        return ResponseEntity.ok(commentService.addChildrenComment(postId,commentId, commentCreateDto, providerId));
+    }
+
+
+}

--- a/src/main/java/com/example/trace/post/domain/Comment.java
+++ b/src/main/java/com/example/trace/post/domain/Comment.java
@@ -1,0 +1,53 @@
+package com.example.trace.post.domain;
+
+import com.example.trace.user.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "comments")
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
+
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    public void addChild(Comment child) {
+        this.children.add(child);
+    }
+
+
+}

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -52,6 +52,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> images = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>();
+
     @CreationTimestamp
     @Column(name = "created_at")
     private LocalDateTime createdAt;
@@ -68,6 +71,10 @@ public class Post {
     public void addImage(PostImage image) {
         this.images.add(image);
         image.setPost(this);
+    }
+
+    public void addComment(Comment comment){
+        this.commentList.add(comment);
     }
 
     public void incrementViewCount() {

--- a/src/main/java/com/example/trace/post/dto/comment/CommentCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/comment/CommentCreateDto.java
@@ -1,0 +1,15 @@
+package com.example.trace.post.dto.comment;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class CommentCreateDto {
+    private String content;
+}

--- a/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
+++ b/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
@@ -1,0 +1,60 @@
+package com.example.trace.post.dto.comment;
+
+import com.example.trace.post.domain.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@Schema(description = "댓글 DTO")
+public class CommentDto {
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+    @Schema(description = "댓글 쓴 사람의 providerID", example = "431256341")
+    private String providerId;
+    @Schema(description = "댓글 ID", example = "1")
+    private Long commentId;
+    @Schema(description = "부모 댓글 ID", example = "1")
+    private Long parentId;
+    @Schema(description = "삭제 여부", example = "false")
+    private boolean isDeleted;
+    @Schema(description = "댓글 소유 여부", example = "true")
+    private boolean isOwner;
+    @Schema(description = "댓글 작성자 닉네임", example = "닉네임")
+    private String nickName;
+    @Schema(description = "댓글 작성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String userProfileImageUrl;
+    @Schema(description = "댓글 내용", example = "댓글 내용")
+    private String content;
+    @Schema(description = "대댓글 리스트")
+    private List<Comment> childrenComments;
+    @Schema(description = "댓글 작성 시간", example = "2023-10-01T12:00:00")
+    private LocalDateTime createdAt;
+
+
+    public static CommentDto fromEntity(Comment comment) {
+        return CommentDto.builder()
+                .postId(comment.getPost().getId())
+                .providerId(comment.getUser().getProviderId())
+                .commentId(comment.getId())
+                .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
+                .isDeleted(false)
+                .isOwner(true)
+                .nickName(comment.getUser().getNickname())
+                .userProfileImageUrl(comment.getUser().getProfileImageUrl())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/com/example/trace/post/repository/CommentRepository.java
+++ b/src/main/java/com/example/trace/post/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.example.trace.post.repository;
+
+import com.example.trace.post.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostIdOrderByCreatedAtDesc(Long postId);
+}

--- a/src/main/java/com/example/trace/post/repository/PostRepository.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepository.java
@@ -5,7 +5,10 @@ import com.example.trace.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findById(Long postId);
 }

--- a/src/main/java/com/example/trace/post/service/CommentService.java
+++ b/src/main/java/com/example/trace/post/service/CommentService.java
@@ -1,0 +1,91 @@
+package com.example.trace.post.service;
+
+import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.global.errorcode.PostErrorCode;
+import com.example.trace.global.exception.PostException;
+import com.example.trace.post.domain.Comment;
+import com.example.trace.post.domain.Post;
+import com.example.trace.post.dto.comment.CommentCreateDto;
+import com.example.trace.post.dto.comment.CommentDto;
+import com.example.trace.post.repository.CommentRepository;
+import com.example.trace.post.repository.PostRepository;
+import com.example.trace.user.User;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+
+    public CommentDto addComment(Long postId ,CommentCreateDto commentCreateDto, String providerId) {
+
+        Post postToAddComment = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        User user = userRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        if (commentCreateDto.getContent() == null || commentCreateDto.getContent().isEmpty()) {
+            throw new PostException(PostErrorCode.CONTENT_EMPTY);
+        }
+
+        Comment comment = Comment.builder()
+                .post(postToAddComment)
+                .content(commentCreateDto.getContent())
+                .user(user)
+                .build();
+        commentRepository.save(comment);
+
+        postToAddComment.addComment(comment);
+
+        return CommentDto.fromEntity(comment);
+    }
+
+    public void deleteComment(Long commentId, String ProviderId) {
+        User user = userRepository.findByProviderId(ProviderId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new PostException(PostErrorCode.COMMENT_NOT_FOUND));
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new PostException(PostErrorCode.COMMENT_DELETE_FORBIDDEN);
+        }
+        commentRepository.delete(comment);
+    }
+
+    public CommentDto addChildrenComment(Long postId,Long commentId,CommentCreateDto commentCreateDto, String ProviderId){
+        User user = userRepository.findByProviderId(ProviderId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        Comment parentComment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new PostException(PostErrorCode.COMMENT_NOT_FOUND));
+
+        if (parentComment.getPost() == null) {
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+        }
+
+        Post postToAddComment = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        if (commentCreateDto.getContent() == null || commentCreateDto.getContent().isEmpty()) {
+            throw new PostException(PostErrorCode.CONTENT_EMPTY);
+        }
+
+        Comment childrenComment = Comment.builder()
+                .post(postToAddComment)
+                .content(commentCreateDto.getContent())
+                .user(user)
+                .parent(parentComment)
+                .build();
+        commentRepository.save(childrenComment);
+
+        parentComment.addChild(childrenComment);
+
+        return CommentDto.fromEntity(childrenComment);
+    }
+
+}

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -59,6 +59,10 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
 
+        if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
+            throw new PostException(PostErrorCode.CONTENT_EMPTY);
+        }
+
 
         Post post = Post.builder()
                 .postType(PostType.valueOf(postCreateDto.getPostType()))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,7 @@ springdoc:
     - /emotion/**
     - /user/**
     - /verification/**
+    - /comments/**
 
 
 
@@ -88,7 +89,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 데이터베이스 스키마 변경

(일단 시간이 촉박하여 댓글 기능 추가 브랜치에서 감정표현 api에 대한 수정사항을 수정하였다.)

감정 표현의 변수명을 맞추기 위해서 

감정표현 타입의 enum 상수값을 바꿨다.

엔티티에 들어갈 필드값이 바꼈지만, ddl-auto : update이므로

스키마가 올바르게 수정되진 않았다.

따라서 ddl-auto : create 로 바꿔서 초기화하기로 하였다.

항상 엔티티 변경 시마다 스키마를 초기화할 순 없으니 

대책을 세워야할 것 같다.


## 2. ✨새롭게 변경된 점

- 댓글 생성

- 댓글 삭제

- 대댓글 생성

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

대댓글 api에서 postId를 클라에서 받아오는게 좋은지,

원댓글의 post를 참조하여 가져오는게 좋을지 모르겠다.
