### PR TITLE
fix : swagger 변수명 동기화 오류

### DIFF
--- a/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
+++ b/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
@@ -15,7 +15,7 @@ public class EmotionResponse {
     @Schema(description = "감정 표현 추가 여부", example = "true")
     @JsonProperty("isAdded")
     private boolean isAdded;
-    @Schema(description = "감정 표현 타입", example = "LIKE")
+    @Schema(description = "감정 표현 타입", example = "LIKEABLE")
     private String emotionType;
     public EmotionResponse(boolean isAdded, String emotionType) {
         this.isAdded = isAdded;

--- a/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
+++ b/src/main/java/com/example/trace/emotion/dto/EmotionResponse.java
@@ -1,6 +1,7 @@
 package com.example.trace.emotion.dto;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.Setter;
 @Schema(description = "감정 표현 응답 DTO")
 public class EmotionResponse {
     @Schema(description = "감정 표현 추가 여부", example = "true")
+    @JsonProperty("isAdded")
     private boolean isAdded;
     @Schema(description = "감정 표현 타입", example = "LIKE")
     private String emotionType;

--- a/src/main/java/com/example/trace/post/domain/PostType.java
+++ b/src/main/java/com/example/trace/post/domain/PostType.java
@@ -1,7 +1,6 @@
 package com.example.trace.post.domain;
 
 public enum PostType {
-    ALL("전체"),
     FREE("자유"),
     GOOD_DEED("선행"),
     MISSION("미션");

--- a/src/main/java/com/example/trace/post/dto/PostCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostCreateDto.java
@@ -19,7 +19,7 @@ import java.util.List;
 public class PostCreateDto {
 
     @NotBlank(message = "게시글 유형을 선택해주세요")
-    @Schema(description = "게시글 유형", example = "ALL")
+    @Schema(description = "게시글 유형", example = "FREE,GOOD_DEED,MISSION")
     private String postType;
     
     @NotBlank(message = "제목을 입력해주세요")

--- a/src/main/java/com/example/trace/post/dto/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostDto.java
@@ -3,6 +3,7 @@ package com.example.trace.post.dto;
 import com.example.trace.emotion.dto.EmotionCountDto;
 import com.example.trace.post.domain.Post;
 import com.example.trace.post.domain.PostImage;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -51,9 +52,11 @@ public class PostDto {
     private String profileImageUrl;
 
     @Schema(description = "게시글 소유 여부", example = "true")
+    @JsonProperty("isOwner")
     private boolean isOwner;
 
     @Schema(description = "게시글 선행 인증 여부", example = "false")
+    @JsonProperty("isVerified")
     private boolean isVerified;
 
     @Schema(description = "게시글 작성일", example = "2023-10-01T12:00:00")

--- a/src/main/java/com/example/trace/post/dto/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/PostDto.java
@@ -24,7 +24,7 @@ public class PostDto {
     @Schema(description = "게시글 ID", example = "1")
     private Long id;
 
-    @Schema(description = "게시글 타입", example = "ALL")
+    @Schema(description = "게시글 타입", example = "FREE, GOOD_DEED, MISSION")
     private String postType;
 
     @Schema(description = "조회수", example = "100")

--- a/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
+++ b/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
@@ -1,6 +1,7 @@
 package com.example.trace.post.dto.comment;
 
 import com.example.trace.post.domain.Comment;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,7 +9,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,26 +16,36 @@ import java.util.List;
 @Data
 @Schema(description = "댓글 DTO")
 public class CommentDto {
+
     @Schema(description = "게시글 ID", example = "1")
     private Long postId;
+
     @Schema(description = "댓글 쓴 사람의 providerID", example = "431256341")
     private String providerId;
+
     @Schema(description = "댓글 ID", example = "1")
     private Long commentId;
+
     @Schema(description = "부모 댓글 ID", example = "1")
     private Long parentId;
+
     @Schema(description = "삭제 여부", example = "false")
+    @JsonProperty("isDeleted")
     private boolean isDeleted;
+
     @Schema(description = "댓글 소유 여부", example = "true")
+    @JsonProperty("isOwner")
     private boolean isOwner;
+
     @Schema(description = "댓글 작성자 닉네임", example = "닉네임")
     private String nickName;
+
     @Schema(description = "댓글 작성자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String userProfileImageUrl;
+
     @Schema(description = "댓글 내용", example = "댓글 내용")
     private String content;
-    @Schema(description = "대댓글 리스트")
-    private List<Comment> childrenComments;
+
     @Schema(description = "댓글 작성 시간", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

swagger api 에서 is로 시작하는 변수들의 is가 없어지는 오류가 있었다.

json으로 직렬화하는 과정 중에 is가 없어지는 것이였고

jsonproperty 애너테이션으로 직접 변수명 지정이 가능했다.

## 2. ✨새롭게 변경된 점

- swagger에서 is로 시작하는 변수가 제대로 나온다

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
