### PR TITLE
feat : 로그아웃 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
@@ -1,17 +1,16 @@
 package com.example.trace.auth;
 
 
+import com.example.trace.global.errorcode.TokenErrorCode;
+import com.example.trace.global.exception.TokenException;
 import com.example.trace.user.User;
 import com.example.trace.auth.dto.PrincipalDetails;
-import com.example.trace.Util.HttpResponseUtil;
 import com.example.trace.auth.Util.JwtUtil;
 import com.example.trace.auth.Util.RedisUtil;
 import com.example.trace.auth.repository.UserRepository;
-import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -68,52 +67,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
         log.info("[*] Jwt Filter - Request URI: {}", request.getRequestURI());
+        String accessToken = jwtUtil.resolveAccessToken(request);
 
-        try {
-            String accessToken = jwtUtil.resolveAccessToken(request);
-
-            // accessToken 없이 접근할 경우
-            if (accessToken == null) {
-                log.info("[*] No accessToken, proceeding to next filter for URI: {}", request.getRequestURI());
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // logout 처리된 accessToken
-            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
-                log.info("[*] Logout accessToken");
-                filterChain.doFilter(request, response);
-                return;
-            }
-
-            // 유효성 검사
-            jwtUtil.validateToken(accessToken);
-
-            // accessToken에서 providerId 추출
-            String providerId = jwtUtil.getProviderId(accessToken);
-            // accessToken에서 providerId로 User 객체를 가져옴
-            User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
-            // accesstoken을 기반으로 principalDetail 저장
-            PrincipalDetails principalDetails = new PrincipalDetails(user);
-
-
-            // 스프링 시큐리티 인증 토큰 생성
-            Authentication authToken = new UsernamePasswordAuthenticationToken(
-                    principalDetails,
-                    null,
-                    principalDetails.getAuthorities());
-
-            // 컨텍스트 홀더에 저장
-            SecurityContextHolder.getContext().setAuthentication(authToken);
-
+        // accessToken 없이 접근할 경우
+        if (accessToken == null) {
+            log.info("[*] No accessToken, proceeding to next filter for URI: {}", request.getRequestURI());
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
-            try {
-                HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, null,"엑세스 토큰이 유효하지 않습니다.");
-            } catch (IOException ex) {
-                log.error("IOException occurred while setting error response: {}", ex.getMessage());
-            }
-            log.warn("[*] case : accessToken Expired");
+            return;
         }
+
+        jwtUtil.validateToken(accessToken);
+
+        // logout 혹은 회원탈퇴 처리된 accessToken
+        if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
+            log.info("[*] Logout or deleted account accessToken");
+            throw new TokenException(TokenErrorCode.LOGOUT_TOKEN);
+        }
+
+        if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("delete")){
+            log.info("[*] Deleted account accessToken");
+            throw new TokenException(TokenErrorCode.DELETED_USER);
+        }
+
+        // 유효성 검사
+        jwtUtil.validateToken(accessToken);
+
+        // accessToken에서 providerId 추출
+        String providerId = jwtUtil.getProviderId(accessToken);
+        // accessToken에서 providerId로 User 객체를 가져옴
+        User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        // accesstoken을 기반으로 principalDetail 저장
+        PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+
+        // 스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(
+                principalDetails,
+                null,
+                principalDetails.getAuthorities());
+
+        // 컨텍스트 홀더에 저장
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+
+
     }
 }

--- a/src/main/java/com/example/trace/global/errorcode/TokenErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/TokenErrorCode.java
@@ -14,6 +14,8 @@ public enum TokenErrorCode implements ErrorCode {
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND,false,true, "리프레시 토큰이 존재하지 않거나, 일치하지 않습니다. "),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND,false,true, "사용자가 존재하지 않습니다"),
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,false,true, "알 수 없는 오류입니다."),
+    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, true, false, "로그아웃된 토큰입니다."),
+    DELETED_USER(HttpStatus.UNAUTHORIZED, true,false,"회원탈퇴한 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/trace/user/UserController.java
+++ b/src/main/java/com/example/trace/user/UserController.java
@@ -1,6 +1,7 @@
 package com.example.trace.user;
 
 import com.example.trace.auth.Util.JwtUtil;
+import com.example.trace.auth.Util.RedisUtil;
 import com.example.trace.user.dto.UserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,16 +10,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user")
 @Tag(name = "User", description = "사용자 정보 API")
+@Slf4j
 public class UserController {
     private final UserService userService;
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
 
     @Operation(summary = "유저 정보 조회", description = "유저 정보를 가져옵니다.")
     @ApiResponse(
@@ -34,5 +41,23 @@ public class UserController {
         String providerId = jwtUtil.getProviderId(token);
         UserDto userDto = userService.getUserInfo(providerId);
         return ResponseEntity.ok(userDto);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
+        String accessToken = jwtUtil.resolveAccessToken(request);
+        if (accessToken != null) {
+            // Get the token's remaining expiration time
+            long expiration = jwtUtil.getExpTime(accessToken);
+            // Add token to blacklist in Redis with "logout" value and expiration time
+            redisUtil.save(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+            String test = (String)redisUtil.get(accessToken);
+            log.info("Logout test: {}", test);
+            // Also delete the refresh token for this user
+            String providerId = jwtUtil.getProviderId(accessToken);
+            String redisKey = "RT:" + providerId;
+            redisUtil.delete(redisKey);
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/trace/user/UserService.java
+++ b/src/main/java/com/example/trace/user/UserService.java
@@ -1,20 +1,47 @@
 package com.example.trace.user;
 
 
+import com.example.trace.auth.Util.JwtUtil;
+import com.example.trace.auth.Util.RedisUtil;
 import com.example.trace.auth.repository.UserRepository;
+import com.example.trace.global.errorcode.TokenErrorCode;
+import com.example.trace.global.exception.TokenException;
 import com.example.trace.user.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
 
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
 
     public UserDto getUserInfo(String providerId) {
         User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
         return new UserDto().fromEntity(user);
+    }
+
+    public void logout(String accessToken) {
+        String providerId = jwtUtil.getProviderId(accessToken);
+        long expiration = jwtUtil.getExpTime(accessToken);
+        redisUtil.save(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+        String redisKey = "RT:" + providerId;
+        redisUtil.delete(redisKey);
+    }
+
+    public void deleteUser(String accessToken) {
+        String providerId = jwtUtil.getProviderId(accessToken);
+        User user = userRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new TokenException(TokenErrorCode.NOT_FOUND_USER));
+        userRepository.delete(user);
+        Long expiration = jwtUtil.getExpTime(accessToken);
+        redisUtil.save(accessToken, "delete", expiration, TimeUnit.MILLISECONDS);
+        String redisKey = "RT:" + providerId;
+        redisUtil.delete(redisKey);
     }
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 로그아웃 / 회원 탈퇴 기능 구현

로그아웃 시, 현재 엑세스 토큰을 레디스에 블랙리스트로 저장해둔다.

레디스에 저장돼있던 리프레시 토큰도 지워버림.

회원 탈퇴는 user 테이블에서 삭제 시키는 것만 추가하면 된다.

로그아웃/회원탈퇴 전에 쓰던 토큰으로 요청을 보내면

로그아웃된 토큰 / 회원탈퇴한 사용자라는 에러 메시지를 보낸다


### 토큰 필터 개선

예외처리를 더 명확하게 할 수 있도록

필터 안에서 jwtUtil의 유효성 검사 메서드를 사용하였다.
(원래 try catch로 만료된 토큰만 잡아내고 있었음)


## 2. ✨새롭게 변경된 점

- 로그아웃 기능 구현

- 회원 탈퇴 기능 구현

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

근데 분명 403으로 상태코드를 지정해놨는데 받는 응답은 500 코드이다.

원인은 아마 상위 예외처리로 넘어간 뒤 에러 메시지를 보내서 그런거 같은데

좀 더 찾아봐야할 것 같다.
