### PR TITLE
fix : 토큰 관련 예외처리 버그 수정

### DIFF
--- a/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/trace/auth/JwtAuthenticationFilter.java
@@ -22,6 +22,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -32,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
+    private final HandlerExceptionResolver handlerExceptionResolver;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     // 인증 객체가 필요 없는 경로 패턴을 정의
@@ -66,51 +69,59 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
-        log.info("[*] Jwt Filter - Request URI: {}", request.getRequestURI());
-        String accessToken = jwtUtil.resolveAccessToken(request);
+        try{
+            log.info("[*] Jwt Filter - Request URI: {}", request.getRequestURI());
+            String accessToken = jwtUtil.resolveAccessToken(request);
 
-        // accessToken 없이 접근할 경우
-        if (accessToken == null) {
-            log.info("[*] No accessToken, proceeding to next filter for URI: {}", request.getRequestURI());
+            // accessToken 없이 접근할 경우
+            if (accessToken == null) {
+                log.info("[*] No accessToken, proceeding to next filter for URI: {}", request.getRequestURI());
+                filterChain.doFilter(request, response);
+                return;
+            }
+            // accessToken이 유효하지 않은 경우
+            jwtUtil.validateToken(accessToken);
+
+            // logout 혹은 회원탈퇴 처리된 accessToken
+            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
+                log.info("[*] Logout or deleted account accessToken");
+                throw new TokenException(TokenErrorCode.LOGOUT_TOKEN);
+            }
+
+            if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("delete")){
+                log.info("[*] Deleted account accessToken");
+                throw new TokenException(TokenErrorCode.DELETED_USER);
+            }
+
+            // 유효성 검사
+            jwtUtil.validateToken(accessToken);
+
+            // accessToken에서 providerId 추출
+            String providerId = jwtUtil.getProviderId(accessToken);
+            // accessToken에서 providerId로 User 객체를 가져옴
+            User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
+            // accesstoken을 기반으로 principalDetail 저장
+            PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+
+            // 스프링 시큐리티 인증 토큰 생성
+            Authentication authToken = new UsernamePasswordAuthenticationToken(
+                    principalDetails,
+                    null,
+                    principalDetails.getAuthorities());
+
+            // 컨텍스트 홀더에 저장
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+
             filterChain.doFilter(request, response);
-            return;
+
+        }catch (TokenException e){
+            log.error("[*] Jwt Filter - TokenException: {}", e.getMessage());
+            handlerExceptionResolver.resolveException(request, response, null, e);
+
+        } catch (Exception e){
+            log.error("[*] Jwt Filter - Exception: {}", e.getMessage());
         }
-
-        jwtUtil.validateToken(accessToken);
-
-        // logout 혹은 회원탈퇴 처리된 accessToken
-        if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("logout")) {
-            log.info("[*] Logout or deleted account accessToken");
-            throw new TokenException(TokenErrorCode.LOGOUT_TOKEN);
-        }
-
-        if (redisUtil.get(accessToken) != null && redisUtil.get(accessToken).equals("delete")){
-            log.info("[*] Deleted account accessToken");
-            throw new TokenException(TokenErrorCode.DELETED_USER);
-        }
-
-        // 유효성 검사
-        jwtUtil.validateToken(accessToken);
-
-        // accessToken에서 providerId 추출
-        String providerId = jwtUtil.getProviderId(accessToken);
-        // accessToken에서 providerId로 User 객체를 가져옴
-        User user = userRepository.findByProviderIdAndProvider(providerId,"KAKAO").orElseThrow(() -> new UsernameNotFoundException("User not found"));
-        // accesstoken을 기반으로 principalDetail 저장
-        PrincipalDetails principalDetails = new PrincipalDetails(user);
-
-
-        // 스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(
-                principalDetails,
-                null,
-                principalDetails.getAuthorities());
-
-        // 컨텍스트 홀더에 저장
-        SecurityContextHolder.getContext().setAuthentication(authToken);
-
-        filterChain.doFilter(request, response);
-
 
     }
 }

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.util.Arrays;
 
@@ -27,6 +28,7 @@ public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
+    private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -60,7 +62,7 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(jwtUtil, redisUtil, userRepository);
+        return new JwtAuthenticationFilter(jwtUtil, redisUtil, userRepository,handlerExceptionResolver);
     }
 
     @Bean

--- a/src/main/java/com/example/trace/token/JwtTokenController.java
+++ b/src/main/java/com/example/trace/token/JwtTokenController.java
@@ -1,7 +1,9 @@
 package com.example.trace.token;
 
 import com.example.trace.auth.dto.TokenResponse;
+import com.example.trace.token.dto.CheckExpRequest;
 import com.example.trace.token.dto.ExpResponse;
+import com.example.trace.token.dto.ReIssueRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -100,11 +102,12 @@ public class JwtTokenController {
             )
         )
     })
-    @GetMapping("/refresh")
+    @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> reissueAccessToken(
         @Parameter(description = "유효한 리프레시 토큰", required = true) 
-        @RequestParam String refreshToken
+        @RequestBody ReIssueRequest request
     ) {
+        String refreshToken = request.getRefreshToken();
         log.info("[*] Access Token 재발급 요청 - refreshToken: {}", refreshToken);
         TokenResponse response = tokenService.reissueAccessToken(refreshToken);
         return ResponseEntity.ok(response);
@@ -168,11 +171,12 @@ public class JwtTokenController {
             )
         )
     })
-    @GetMapping("/expiration")
+    @PostMapping("/expiration")
     public ResponseEntity<ExpResponse> checkTokenExpiration(
-        @Parameter(description = "확인할 JWT 토큰", required = true) 
-        @RequestParam String token
+            @Parameter(description = "확인할 JWT 토큰", required = true)
+            @RequestBody CheckExpRequest request
     ) {
+        String token = request.getToken();
         log.info("[*] 토큰 만료 확인 요청 - token: {}", token);
         boolean isExpired = tokenService.checkTokenExpiration(token);
         ExpResponse response = new ExpResponse(isExpired);

--- a/src/main/java/com/example/trace/token/dto/CheckExpRequest.java
+++ b/src/main/java/com/example/trace/token/dto/CheckExpRequest.java
@@ -1,0 +1,16 @@
+package com.example.trace.token.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "토큰 만료 확인 요청")
+public class CheckExpRequest {
+    @Schema(description = "JWT 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String token;
+
+}

--- a/src/main/java/com/example/trace/token/dto/ExpResponse.java
+++ b/src/main/java/com/example/trace/token/dto/ExpResponse.java
@@ -1,10 +1,17 @@
 package com.example.trace.token.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Schema(description = "토큰 만료 확인 응답")
 public class ExpResponse {
+    @Schema(description = "토큰 만료 여부", example = "true")
+    @JsonProperty("isExpired")
     private boolean isExpired;
 }

--- a/src/main/java/com/example/trace/token/dto/ReIssueRequest.java
+++ b/src/main/java/com/example/trace/token/dto/ReIssueRequest.java
@@ -1,0 +1,15 @@
+package com.example.trace.token.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "토큰 재발급 요청")
+public class ReIssueRequest {
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

### 잘못된 응답 코드

커스텀 전역 예외처리를 도입하고 난 뒤,

토큰 관련 예외처리가 제대로 되고 있지 않았다.

만료된 토큰으로 api에 요청을 했을 때, 401 에러가 떠야하는데

500 에러가 떴다.

- 원인 : 요청보낼 때, 필터 체인은 일반적인 spring의 예외처리(ControllerAdvice/ExceptionHandler) 이전에 실행되므로 커스텀 예외처리기가 이걸 잡지 못함

필터는 Spring MVC의 DispatcherServlet 이전에 실행되기 때문에 기본적으로 @ControllerAdvice나 @ExceptionHandler에 도달하지 않지만 필터에 HandlerExceptionResolver 주입하여 사용하면 커스텀 예외처리기를 사용할 수 있다.

## 2. ✨새롭게 변경된 점

- 토큰에 문제가 있어서 예외처리 시, 적절한 에러 메시지를 보내준다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
