### PR TITLE
fix : 참조 무결성 제약조건으로 인해 회원 탈퇴 오류

### DIFF
--- a/src/main/java/com/example/trace/post/domain/Comment.java
+++ b/src/main/java/com/example/trace/post/domain/Comment.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,12 +25,13 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.ALL,fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

연관관계를 살펴보면 

user <- post <-> comment -> user이다.

즉, post와 comment가 user를 참조하고 있고,
comment와 post가 서로 참조하고 있다.

(comment와 post가 양방향 참조인 이유는 post 조회 시, comment들을 쉽게 보내기 위함이였는데,
post와 comment 조회 api가 분리될 것이므로 아마 수정이 필요할 것 같다.)

user를 삭제하면, user를 참조하고 있는 comment와 post가 가지고 있는 외래키 값이 무쓸모가 되기 때문에
참조 무결성 제약조건에 위반되므로 적절한 조치가 필요하다. 

처음엔 연관관계 애너테이션에 @ ManyToOne(cascade = CascadeType.ALL) 
이런 식으로 설정했다. 그냥 cascade 설정하면 뭐 알아서 삭제되는거 아닌가 하는 생각이였다. 

하지만 user 삭제 시도 -> comment 삭제 시도 -> comment가 참조하고 있는 user를 삭제 시도... 
와 같이 순환 참조를 일으키기 때문에 
데이터 베이스 수준에서 삭제를 하도록 해야한다. 

즉 @ Ondelete 애너테이션을 사용해야 한다. 

<img src="https://github.com/user-attachments/assets/3f0f701f-3087-4b54-8cdc-7aa85a227e8d" width="500" height="300">



## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

연관 관계에서 다대일 관계일 때, 
보통 다 쪽이 외래키를 가지고 있기 때문에
다 쪽이 연관관계의 주인이 되는게 맞다. 
부모 자식에서 자식이 주인이 되는 것.

다 쪽만 일 쪽을 참조하는 단방향 관계로도 충분.
양방향 관계에선 주인이 아닌 엔티티에서 mapped by로 주인이 아님을 명시한다. 

@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Comment> commentList = new ArrayList<>();
  
POST 엔티티에서 comment를 참조할 때, 주인이 아님을 mappedBy로 표시
mappedBy는 해당 필드의 객체에서 mappedBy의 값을 필드명으로 하여 this를 참조하고 있다는 것
