### PR TITLE
fix : 참조 무결성 제약조건으로 인해 회원 탈퇴 오류(2)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ fix/jiseob/#69 ]
+    branches: [ develop ]
 #테스트6
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ fix/jiseob/#69 ]
 #테스트6
 jobs:
   build:

--- a/src/main/java/com/example/trace/post/domain/Comment.java
+++ b/src/main/java/com/example/trace/post/domain/Comment.java
@@ -25,7 +25,7 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL,fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/com/example/trace/post/domain/Comment.java
+++ b/src/main/java/com/example/trace/post/domain/Comment.java
@@ -27,6 +27,7 @@ public class Comment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -52,7 +52,7 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostImage> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "post", orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
     @CreationTimestamp

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,7 +91,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,7 +91,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,7 +91,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: dev
+    active: local
 
 # AWS S3 설정
 cloud:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,8 @@ logging:
     org.hibernate: INFO
     com.example.trace: DEBUG
     org.springframework.security: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql: TRACE
 
 
 ---
@@ -95,6 +97,7 @@ spring:
         format_sql: true
         show_sql: false
         dialect: org.hibernate.dialect.MySQL8Dialect
+
 
   sql:
     init:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,7 +89,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

가장 핵심적인 원인은 연관관계의 제약조건을 제대로 살피지 못한 것이다.

해당 이슈의 첫번째 pr에서 **comment가 post를 참조하고 있었는데, ondelete를 추가하지 않았다.**

추가 하고 나서도, **ddl-auto를 update로 두고** 푸시를 해서 스키마 변경이 안돼서, 제약조건은 그대로였기 때문에 회원 탈퇴가 제대로 되지 않았다.

ddl-auto를 create로 두니, 스키마 변경이 제대로 돼서 제약조건이 변경돼서 회원탈퇴도 수월하게 됐다.

그런데, db를 살펴봤는데 민준이가 가입해놓은 user 데이터는 그대로여서 좀 당황을 했던 것 같다. 

데이터 베이스가 아예 초기화돼야하는데, 그게 안됐다. 

일단 원인은 데이터 베이스에 daily-mission, mission 등의 테이블을 예전에 sql 문으로 생성한 적이 있었기 때문이다 .

그리고 해당 테이블을 user의 외래키를 가지고 있었기 때문에 user가 삭제가 안됐던 것. 

배포 환경에서 서버 로그 보는건 좀 번거롭기 때문에 개발 환경에서 해볼 수 있는 테스트를 다 해보고 배포하는게 좋을 것 같다고 생각이 들었다.


## 2. ✨새롭게 변경된 점

- 회원 탈퇴 기능 작동됨

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
