### PR TITLE
feat : 커서 기반 게시글 페이징 조회 구현

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ feature/jiseob/#71 ]
 #테스트6
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ feature/jiseob/#71 ]
+    branches: [ develop ]
 #테스트6
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ repositories {
 	mavenCentral()
 }
 
+
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -56,6 +58,31 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+}
+
+
+// 최신 방식으로 querydsl 디렉토리 지정
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// 소스 세트 설정
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+// 자바 컴파일러 설정
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// clean 태스크 설정
+clean {
+	delete querydslDir
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/trace/config/QuerydslConfig.java
+++ b/src/main/java/com/example/trace/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.trace.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -2,7 +2,7 @@ package com.example.trace.gpt.service;
 
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
-import com.example.trace.post.dto.PostCreateDto;
+import com.example.trace.post.dto.post.PostCreateDto;
 
 public interface PostVerificationService {
     VerificationDto verifyPost(PostCreateDto postCreateDto,String providerId);

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -6,7 +6,7 @@ import com.example.trace.global.exception.GptException;
 import com.example.trace.global.exception.PostException;
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
-import com.example.trace.post.dto.PostCreateDto;
+import com.example.trace.post.dto.post.PostCreateDto;
 import com.example.trace.user.User;
 import com.example.trace.auth.repository.UserRepository;
 import com.theokanning.openai.completion.chat.ChatCompletionRequest;

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -2,11 +2,14 @@ package com.example.trace.post.controller;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.gpt.service.PostVerificationService;
+import com.example.trace.post.dto.cursor.CursorResponse;
+import com.example.trace.post.dto.cursor.PostCursorRequest;
+import com.example.trace.post.dto.post.PostFeedDto;
 import com.example.trace.user.User;
 import com.example.trace.auth.dto.PrincipalDetails;
-import com.example.trace.post.dto.PostCreateDto;
-import com.example.trace.post.dto.PostDto;
-import com.example.trace.post.dto.PostUpdateDto;
+import com.example.trace.post.dto.post.PostCreateDto;
+import com.example.trace.post.dto.post.PostDto;
+import com.example.trace.post.dto.post.PostUpdateDto;
 import com.example.trace.post.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -114,6 +117,18 @@ public class PostController {
         String providerId = principalDetails.getUser().getProviderId();
         PostDto post = postService.getPostById(id,providerId);
         return ResponseEntity.ok(post);
+    }
+
+    @PostMapping("/feed")
+    @Operation(summary = "게시글 커서 기반 페이징 조회", description = "커서 기반 페이징으로 게시글을 조회합니다.")
+    public ResponseEntity<CursorResponse<PostFeedDto>> getAllPosts(
+            @RequestBody PostCursorRequest request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String providerId = principalDetails.getUser().getProviderId();
+        CursorResponse<PostFeedDto> response = postService.getAllPostsWithCursor(
+                request, providerId != null ? providerId : null);
+
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/com/example/trace/post/dto/cursor/CursorResponse.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/CursorResponse.java
@@ -1,0 +1,32 @@
+package com.example.trace.post.dto.cursor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CursorResponse<T> {
+    private List<T> content;
+    private boolean hasNext;
+    private CursorMeta cursor;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "게시글 커서 메타 정보")
+    public static class CursorMeta {
+        @Schema(description = "커서 날짜 및 시간", example = "2025-05-22T08:26:36.025Z")
+        private LocalDateTime dateTime;
+        @Schema(description = "커서 ID", example = "71")
+        private Long id;
+    }
+}

--- a/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
@@ -1,0 +1,24 @@
+package com.example.trace.post.dto.cursor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시글 커서 요청 DTO")
+public class PostCursorRequest {
+    @Schema(description = "커서 날짜 및 시간(첫 요청일 시, null)", example = "2025-05-22T08:26:36.025Z")
+    private LocalDateTime cursorDateTime;
+    @Schema(description = "커서 ID(첫 요청일 시, null)", example = "71")
+    private Long cursorId;
+    @Schema(description = "페이지 크기", example = "10")
+    private Integer size = 10; // 기본 페이지 크기
+    @Schema(description = "게시글 타입", example = "MISSION")
+    private String postType; // 필터링을 위한 게시글 타입 (선택적)
+}

--- a/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
@@ -1,4 +1,4 @@
-package com.example.trace.post.dto;
+package com.example.trace.post.dto.post;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/example/trace/post/dto/post/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostDto.java
@@ -1,4 +1,4 @@
-package com.example.trace.post.dto;
+package com.example.trace.post.dto.post;
 
 import com.example.trace.emotion.dto.EmotionCountDto;
 import com.example.trace.post.domain.Post;

--- a/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
@@ -1,0 +1,55 @@
+package com.example.trace.post.dto.post;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시글 피드 DTO")
+public class PostFeedDto {
+    @Schema(description = "게시글 ID", example = "1")
+    private Long postId;
+
+    @Schema(description = "게시글 타입", example = "MISSION")
+    private String postType;
+
+    @Schema(description = "게시글 제목", example = "제목")
+    private String title;
+
+    @Schema(description = "게시글 내용", example = "내용")
+    private String content;
+
+    @Schema(description = "providerId", example = "41564..")
+    private String providerId;
+
+    @Schema(description = "닉네임", example = "원지섭")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String profileImageUrl;
+
+    @Schema(description = "게시글 이미지 URL", example = "https://example.com/image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "게시글 조회수", example = "100")
+    private Long viewCount;
+
+    @Schema(description = "게시글 댓글 수", example = "50")
+    private Long commentCount;
+
+    @Schema(description = "생성 시간", example = "2025-05-22T08:29:59.687Z")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정 시간", example = "2025-05-22T08:29:59.687Z")
+    private LocalDateTime updatedAt;
+
+    @Schema(description = "인증 여부", example = "false")
+    private boolean isVerified;
+}

--- a/src/main/java/com/example/trace/post/dto/post/PostUpdateDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostUpdateDto.java
@@ -1,4 +1,4 @@
-package com.example.trace.post.dto;
+package com.example.trace.post.dto.post;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/trace/post/repository/PostRepository.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepository.java
@@ -2,13 +2,23 @@ package com.example.trace.post.repository;
 
 
 import com.example.trace.post.domain.Post;
+import com.example.trace.post.dto.post.PostFeedDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
     Optional<Post> findById(Long postId);
+    List<PostFeedDto> findPostsWithCursor(
+            LocalDateTime cursorDateTime,
+            Long cursorId,
+            int size,
+            String postType);
+
+
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.example.trace.post.repository;
+
+import com.example.trace.post.dto.post.PostFeedDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PostRepositoryCustom {
+    List<PostFeedDto> findPostsWithCursor(
+            LocalDateTime cursorDateTime,
+            Long cursorId,
+            int size,
+            String postType
+    );
+}

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -1,0 +1,107 @@
+package com.example.trace.post.repository;
+
+import com.example.trace.post.domain.QPost;
+import com.example.trace.post.domain.QPostImage;
+import com.example.trace.post.dto.post.PostFeedDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.trace.post.domain.QPost.post;
+
+public class PostRepositoryCustomImpl implements PostRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    // 생성자 주입
+    public PostRepositoryCustomImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    private BooleanExpression postTypeEq(String postType) {
+        return postType != null ? post.postType.stringValue().eq(postType) : Expressions.TRUE;
+    }
+
+    private BooleanExpression cursorCondition(LocalDateTime cursorDateTime, Long cursorId) {
+        if (cursorDateTime == null || cursorId == null) {
+            return Expressions.TRUE; // 첫 페이지
+        }
+        // 커서 이전의 데이터를 가져오는 조건
+        return post.createdAt.lt(cursorDateTime)
+                .or(post.createdAt.eq(cursorDateTime).and(post.id.lt(cursorId)));
+    }
+
+
+
+    @Override
+    public List<PostFeedDto> findPostsWithCursor(
+            LocalDateTime cursorDateTime,
+            Long cursorId,
+            int size,
+            String postType) {
+
+        // Q클래스 정의
+        QPost post = QPost.post;
+        QPostImage postImage = new QPostImage("postImage");
+
+
+        // 이미지 URL 처리를 위한 case 표현식
+        StringExpression imageUrlExpr = Expressions.cases()
+                .when(post.images.isEmpty())
+                .then("")
+                .otherwise(
+                        JPAExpressions
+                                .select(postImage.imageUrl)
+                                .from(postImage)
+                                .where(postImage.post.eq(post))
+                                .orderBy(postImage.id.asc())
+                                .limit(1)
+                );
+
+        // verification 여부 처리를 위한 case 표현식
+        BooleanExpression isVerifiedExpr = Expressions.cases()
+                .when(post.verification.isNull())
+                .then(false)
+                .otherwise(
+                        Expressions.booleanOperation(
+                                com.querydsl.core.types.Ops.OR,
+                                post.verification.isImageVerified,
+                                post.verification.isTextVerified
+                        )
+                );
+
+        return queryFactory
+                .select(Projections.constructor(PostFeedDto.class,
+                        post.id.as("postId"),
+                        post.postType.stringValue(),
+                        post.title,
+                        post.content,
+                        post.user.providerId,
+                        post.user.nickname,
+                        post.user.profileImageUrl,
+                        imageUrlExpr, // 서브쿼리 사용
+                        post.viewCount,
+                        post.commentList.size().longValue(),
+                        post.createdAt,
+                        post.updatedAt,
+                        isVerifiedExpr
+                ))
+                .from(post)
+                .leftJoin(post.user)
+                .leftJoin(post.verification) // verification 조인 추가
+                .leftJoin(post.images, postImage).on(postImage.order.eq(1))
+                .where(
+                        postTypeEq(postType),
+                        cursorCondition(cursorDateTime, cursorId) // 커서 조건
+                )
+                .orderBy(post.createdAt.desc(), post.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/trace/post/service/PostService.java
+++ b/src/main/java/com/example/trace/post/service/PostService.java
@@ -1,9 +1,12 @@
 package com.example.trace.post.service;
 
 import com.example.trace.gpt.dto.VerificationDto;
-import com.example.trace.post.dto.PostUpdateDto;
-import com.example.trace.post.dto.PostCreateDto;
-import com.example.trace.post.dto.PostDto;
+import com.example.trace.post.dto.cursor.CursorResponse;
+import com.example.trace.post.dto.cursor.PostCursorRequest;
+import com.example.trace.post.dto.post.PostFeedDto;
+import com.example.trace.post.dto.post.PostUpdateDto;
+import com.example.trace.post.dto.post.PostCreateDto;
+import com.example.trace.post.dto.post.PostDto;
 
 
 public interface PostService {
@@ -15,7 +18,7 @@ public interface PostService {
     PostDto getPostById(Long id,String providerId);
 
     PostDto updatePost(Long id, PostUpdateDto postUpdateDto,String providerId);
-    
+    CursorResponse<PostFeedDto> getAllPostsWithCursor(PostCursorRequest request, String requesterId);
     void deletePost(Long id, String providerId);
 
 } 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local
+    active: dev
 
 # AWS S3 설정
 cloud:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

오프셋 기반 페이징 처리를 하면 

데이터 유실 및 n+1 문제가 발생하기 때문에 

커서 기반으로 구현하기로 했다. 

커서 기반은 쿼리가 유연해야하므로

querydsl 로 동적 쿼리를 구현했다. 

## 2. ✨새롭게 변경된 점

- 페이징 기반으로 게시글을 전체 조회할 수 있다.

- 페이징 기반으로 게시글을 타입별로 조회할 수 있다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
