### PR TITLE
feat : 커서 기반 댓글 페이징 조회

### DIFF
--- a/src/main/java/com/example/trace/post/domain/Comment.java
+++ b/src/main/java/com/example/trace/post/domain/Comment.java
@@ -37,10 +37,14 @@ public class Comment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment parent;
 
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
     @Builder.Default
-    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "parent")
     private List<Comment> children = new ArrayList<>();
 
     private String content;
@@ -53,5 +57,8 @@ public class Comment {
         this.children.add(child);
     }
 
+    public void removeSelf() {
+        this.isDeleted = true;
+    }
 
 }

--- a/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
+++ b/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
@@ -9,6 +9,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -29,7 +31,7 @@ public class CommentDto {
     @Schema(description = "부모 댓글 ID", example = "1")
     private Long parentId;
 
-    @Schema(description = "삭제 여부", example = "false")
+    @Schema(description = "댓글 삭제 여부", example = "false")
     @JsonProperty("isDeleted")
     private boolean isDeleted;
 
@@ -49,6 +51,25 @@ public class CommentDto {
     @Schema(description = "댓글 작성 시간", example = "2023-10-01T12:00:00")
     private LocalDateTime createdAt;
 
+    @Schema(description = "자식 댓글 리스트")
+    @Builder.Default
+    private List<CommentDto> children = new ArrayList<>();
+
+    // Projections.constructor용 생성자 (children 제외)
+    public CommentDto(Long postId, String providerId, Long commentId, Long parentId,
+                      String nickName, String userProfileImageUrl, String content,
+                      LocalDateTime createdAt, boolean isOwner) {
+        this.postId = postId;
+        this.providerId = providerId;
+        this.commentId = commentId;
+        this.parentId = parentId;
+        this.nickName = nickName;
+        this.userProfileImageUrl = userProfileImageUrl;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.isOwner = isOwner;
+        this.children = new ArrayList<>();
+    }
 
     public static CommentDto fromEntity(Comment comment) {
         return CommentDto.builder()
@@ -64,6 +85,19 @@ public class CommentDto {
                 .createdAt(comment.getCreatedAt())
                 .build();
     }
+
+
+    // 자식 댓글 추가 메서드
+    public void addChild(CommentDto child) {
+        this.children.add(child);
+    }
+
+    // 부모 댓글인지 확인
+    public boolean isParent() {
+        return this.parentId == null;
+    }
+
+
 
 
 

--- a/src/main/java/com/example/trace/post/dto/cursor/CommentCursorRequest.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/CommentCursorRequest.java
@@ -1,0 +1,25 @@
+package com.example.trace.post.dto.cursor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "게시글 커서 요청 DTO")
+public class CommentCursorRequest {
+    @Schema(description = "커서 날짜 및 시간(첫 요청일 시, null)", example = "null")
+    private LocalDateTime cursorDateTime;
+
+    @Schema(description = "커서 ID(첫 요청일 시, null)", example = "null")
+    private Long cursorId;
+
+    @Schema(description = "페이지 크기", example = "10")
+    private Integer size = 10; // 기본 페이지 크기
+}

--- a/src/main/java/com/example/trace/post/dto/cursor/CursorResponse.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/CursorResponse.java
@@ -22,7 +22,7 @@ public class CursorResponse<T> {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "게시글 커서 메타 정보")
+    @Schema(description = "커서 메타 정보")
     public static class CursorMeta {
         @Schema(description = "커서 날짜 및 시간", example = "2025-05-22T08:26:36.025Z")
         private LocalDateTime dateTime;

--- a/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
@@ -13,9 +13,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Schema(description = "게시글 커서 요청 DTO")
 public class PostCursorRequest {
-    @Schema(description = "커서 날짜 및 시간(첫 요청일 시, null)", example = "2025-05-22T08:26:36.025Z")
+    @Schema(description = "커서 날짜 및 시간(첫 요청일 시, null)", example = "null")
     private LocalDateTime cursorDateTime;
-    @Schema(description = "커서 ID(첫 요청일 시, null)", example = "71")
+    @Schema(description = "커서 ID(첫 요청일 시, null)", example = "null")
     private Long cursorId;
     @Schema(description = "페이지 크기", example = "10")
     private Integer size = 10; // 기본 페이지 크기

--- a/src/main/java/com/example/trace/post/repository/CommentRepository.java
+++ b/src/main/java/com/example/trace/post/repository/CommentRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, PostRepositoryCustom {
     List<Comment> findByPostIdOrderByCreatedAtDesc(Long postId);
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.example.trace.post.repository;
 
+import com.example.trace.post.dto.comment.CommentDto;
 import com.example.trace.post.dto.post.PostFeedDto;
 
 import java.time.LocalDateTime;
@@ -11,5 +12,16 @@ public interface PostRepositoryCustom {
             Long cursorId,
             int size,
             String postType
+    );
+
+    List<CommentDto> findComments(
+            List<Long> parentCommentIds,
+            String providerId
+    );
+    List<Long> findParentCommentsIdWithCursor(LocalDateTime cursorDateTime,
+                                                    Long cursorId,
+                                                    Long postId,
+                                                    int size,
+                                                    String providerId
     );
 }


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

댓글을 페이징하여 조회해야하는데,

댓글과 대댓글을 얼마나 불러올지에 대해서 애매했다.

대댓글도 함께 불러와야하는데, 대댓글의 갯수는 다 다르니까, 

10개를 가져와야할 때, 대댓글의 처리가 까다로웠다.

그래서 일단 부모 댓글을 10개 가져오고, 자식 댓글은 개수 상관없이 부모 댓글에 리스트로 포함시켜서 가져오기로 했다.

## 2. ✨새롭게 변경된 점

- 댓글을 페이징 기반으로 빠르게 조회할 수 있다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
