### PR TITLE
fix : 댓글 오류 수정

### DIFF
--- a/src/main/java/com/example/trace/post/controller/CommentController.java
+++ b/src/main/java/com/example/trace/post/controller/CommentController.java
@@ -50,8 +50,8 @@ public class CommentController {
             @PathVariable Long commentId,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         String providerId = principalDetails.getUser().getProviderId();
-        commentService.deleteComment(commentId, providerId);
-        return ResponseEntity.noContent().build();
+        CommentDto commentDto = commentService.deleteComment(commentId, providerId);
+        return ResponseEntity.ok(commentDto);
     }
 
     @Operation(summary = "대댓글 작성", description = "게시글에 대댓글을 작성합니다.")

--- a/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
+++ b/src/main/java/com/example/trace/post/dto/comment/CommentDto.java
@@ -58,7 +58,7 @@ public class CommentDto {
     // Projections.constructor용 생성자 (children 제외)
     public CommentDto(Long postId, String providerId, Long commentId, Long parentId,
                       String nickName, String userProfileImageUrl, String content,
-                      LocalDateTime createdAt, boolean isOwner) {
+                      LocalDateTime createdAt, boolean isOwner,boolean isDeleted) {
         this.postId = postId;
         this.providerId = providerId;
         this.commentId = commentId;
@@ -69,16 +69,17 @@ public class CommentDto {
         this.createdAt = createdAt;
         this.isOwner = isOwner;
         this.children = new ArrayList<>();
+        this.isDeleted = isDeleted;
     }
 
-    public static CommentDto fromEntity(Comment comment) {
+    public static CommentDto fromEntity(Comment comment,String providerId) {
         return CommentDto.builder()
                 .postId(comment.getPost().getId())
                 .providerId(comment.getUser().getProviderId())
                 .commentId(comment.getId())
                 .parentId(comment.getParent() != null ? comment.getParent().getId() : null)
-                .isDeleted(false)
-                .isOwner(true)
+                .isDeleted(comment.isDeleted())
+                .isOwner(comment.getUser().getProviderId().equals(providerId))
                 .nickName(comment.getUser().getNickname())
                 .userProfileImageUrl(comment.getUser().getProfileImageUrl())
                 .content(comment.getContent())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local
+    active: dev
 
 # AWS S3 설정
 cloud:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

- 댓글 삭제를 해도 isDeleted 가 false.

댓글 삭제 시, 엔티티의 내부 메서드로 isDeleted 변수를 false로 바꾸게 했는데

@Transactional 애너테이션이 없어서 db에 커밋이 되지 않았다

왜냐하면 해당 애너테이션 없이는 hibernate의 변경감지가 작동하지 않기 때문이다

변경 감지가 작동하면 영속 상태의 엔티티의 변화를 감지하고 트랜잭션이 커밋될 때, db에 반영한다.


- 댓글이 최신순으로 조회된다

쿼리에서 orderby 오름차순으로 변경

- 커서를 넘겼는데, 바로 전 조회 데이터가 똑같이 응답으로 나온다

커서 조건이 엉망진창이였음. 커서 조건이 post 기준으로 돼있어서, 커서보다 localdatetime이 더 작거나, id가 더 작은 post에서 찾으라는 조건이 붙어버렸다. 

그래서 커서 조건을 comment로 바꾸고,  localdatetime이 더 큰 comment를 찾도록 바꿨다.

## 2. ✨새롭게 변경된 점

- 댓글 삭제 시, isDeleted가 true로 db에 적용이 되고, 조회 시에도 잘 나온다.
- 댓글 페이징 조회 시, 오래된 순서로 조회된다
- 커서를 넘겨서 댓글 페이징 조회 시, 오류없이 잘 나온다

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들

영속성 컨텍스트와 jpa,hibernate에 대해서 더 깊은 공부가 필요할 것 같다. 

