### PR TITLE
fix : 미션 할당 시간 16시, isOwner 판별 로직 개선

### DIFF
--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -43,7 +43,7 @@ public class DailyMissionService {
     private static final int MAX_CHANGES_PER_DAY = 10;
 
 
-    @Scheduled(cron = "0 17 23 * * *")
+    @Scheduled(cron = "0 00 16 * * *")
     @Transactional
     public void assignDailyMissionsToAllUsers() {
         try {

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -132,7 +132,8 @@ public class PostServiceImpl implements PostService {
         PostDto postDto = PostDto.fromEntity(post);
 
         postDto.setEmotionCount(emotionCountDto);
-        postDto.setOwner(post.getUser().equals(user));
+        postDto.setOwner(post.getUser().getProviderId().equals(user.getProviderId()));
+
         postDto.setYourEmotionType(yourEmotionType);
 
         return postDto;


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

## 2. ✨새롭게 변경된 점

isOwner 판별을 user 객체 끼리가 아닌 providerId 끼리 비교하도록 하였다

테스트를 위해 일단 미션 할당 시간을 16시로 하였다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
