### PR TITLE
fix : 수정사항 통합 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ fix/jiseob/#100 ]
+    branches: [ develop ]
 #테스트6
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ fix/jiseob/#100 ]
 #테스트6
 jobs:
   build:

--- a/src/main/java/com/example/trace/emotion/EmotionService.java
+++ b/src/main/java/com/example/trace/emotion/EmotionService.java
@@ -66,7 +66,7 @@ public class EmotionService {
                 .gratefulCount(gratefulCount)
                 .impressiveCount(impressiveCount)
                 .touchingCount(touchingCount)
-                .likableCount(likeableCount)
+                .likeableCount(likeableCount)
                 .build();
     }
 

--- a/src/main/java/com/example/trace/mission/repository/DailyMissionRepository.java
+++ b/src/main/java/com/example/trace/mission/repository/DailyMissionRepository.java
@@ -17,7 +17,4 @@ public interface DailyMissionRepository extends JpaRepository<DailyMission, Long
     // 특정 사용자와 날짜의 미션 여부 확인
     Optional<DailyMission> findByUserAndDate(User user, LocalDate date);
 
-    @Modifying
-    @Query("UPDATE DailyMission d SET d.changeCount = 0 WHERE d.date = :date")
-    void resetChangeCount(@Param("date") LocalDate date);
 }

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -116,6 +116,7 @@ public class PostController {
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
         PostDto postDto = postService.getPostById(id,user);
+
         return ResponseEntity.ok(postDto);
     }
 

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -115,8 +115,8 @@ public class PostController {
             @PathVariable Long id,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
-        PostDto post = postService.getPostById(id,user);
-        return ResponseEntity.ok(post);
+        PostDto postDto = postService.getPostById(id,user);
+        return ResponseEntity.ok(postDto);
     }
 
     @PostMapping("/feed")

--- a/src/main/java/com/example/trace/post/dto/post/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostDto.java
@@ -69,6 +69,9 @@ public class PostDto {
 
     @Schema(description = "게시글 수정일", example = "2023-10-01T12:00:00")
     private LocalDateTime updatedAt;
+
+    @Schema(description = "미션 게시글일 때 보낼 content", example = "부모님 심부름에 다녀왔습니다.")
+    private String missionContent;
     
     public static PostDto fromEntity(Post post) {
         List<String> imageUrls = post.getImages() != null ? 

--- a/src/main/java/com/example/trace/post/dto/post/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostDto.java
@@ -91,6 +91,14 @@ public class PostDto {
                                 (post.getVerification().isImageVerified() ||
                                         post.getVerification().isTextVerified())
                 )
+                .emotionCount(
+                        EmotionCountDto.builder()
+                                .heartwarmingCount(0L)
+                                .gratefulCount(0L)
+                                .impressiveCount(0L)
+                                .likeableCount(0L)
+                                .touchingCount(0L)
+                                .build())
                 .isOwner(true)
                 .profileImageUrl(post.getUser().getProfileImageUrl())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
@@ -1,6 +1,7 @@
 package com.example.trace.post.dto.post;
 
 import com.example.trace.post.domain.PostType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,5 +53,10 @@ public class PostFeedDto {
     private LocalDateTime updatedAt;
 
     @Schema(description = "인증 여부", example = "false")
+    @JsonProperty(value = "isVerified")
     private boolean isVerified;
+
+    @Schema(description = "본인 여부", example = "false")
+    @JsonProperty(value = "isOwner")
+    private boolean isOwner;
 }

--- a/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostFeedDto.java
@@ -59,4 +59,7 @@ public class PostFeedDto {
     @Schema(description = "본인 여부", example = "false")
     @JsonProperty(value = "isOwner")
     private boolean isOwner;
+
+    @Schema(description = "감정표현 개수", example ="12")
+    private Long emotionCountSum;
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepository.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepository.java
@@ -19,7 +19,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
             LocalDateTime cursorDateTime,
             Long cursorId,
             int size,
-            PostType postType);
+            PostType postType,
+            String providerId);
 
 
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
@@ -13,7 +13,8 @@ public interface PostRepositoryCustom {
             LocalDateTime cursorDateTime,
             Long cursorId,
             int size,
-            PostType postType
+            PostType postType,
+            String providerId
     );
 
     List<CommentDto> findComments(

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -7,9 +7,11 @@ import com.example.trace.post.domain.QPostImage;
 import com.example.trace.post.domain.cursor.SearchType;
 import com.example.trace.post.dto.comment.CommentDto;
 import com.example.trace.post.dto.post.PostFeedDto;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.LocalDateTime;
 import java.util.*;
 
+import static com.example.trace.emotion.QEmotion.emotion;
 import static com.example.trace.post.domain.QComment.comment;
 import static com.example.trace.post.domain.QPost.post;
 import static com.example.trace.post.domain.QPostImage.postImage;
@@ -68,6 +71,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                 .otherwise(false);
         return isOwnerExpr;
     }
+
+
 
     private BooleanExpression postCursorCondition(LocalDateTime cursorDateTime, Long cursorId) {
         if (cursorDateTime == null || cursorId == null) {
@@ -119,6 +124,11 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
         QPost post = QPost.post;
         QPostImage postImage = new QPostImage("postImage");
 
+        Expression<Long> totalEmotionCount = JPAExpressions
+                .select(emotion.count())
+                .from(emotion)
+                .where(emotion.post.eq(post));
+
 
         return queryFactory
                 .select(Projections.constructor(PostFeedDto.class,
@@ -135,7 +145,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.createdAt,
                         post.updatedAt,
                         isVerifiedExpr,
-                        isOwnerExpr(providerId)
+                        isOwnerExpr(providerId),
+                        totalEmotionCount
                 ))
                 .from(post)
                 .leftJoin(post.user)
@@ -259,9 +270,6 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
 
         return allComments;
     }
-
-
-
 
 
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -61,6 +61,14 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                     )
             );
 
+    private BooleanExpression isOwnerExpr(String providerId){
+        BooleanExpression isOwnerExpr = Expressions.cases()
+                .when(post.user.providerId.eq(providerId))
+                .then(true)
+                .otherwise(false);
+        return isOwnerExpr;
+    }
+
     private BooleanExpression postCursorCondition(LocalDateTime cursorDateTime, Long cursorId) {
         if (cursorDateTime == null || cursorId == null) {
             return Expressions.TRUE; // 첫 페이지
@@ -104,7 +112,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
             LocalDateTime cursorDateTime,
             Long cursorId,
             int size,
-            PostType postType) {
+            PostType postType,
+            String providerId) {
 
         // Q클래스 정의
         QPost post = QPost.post;
@@ -125,7 +134,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.commentList.size().longValue(),
                         post.createdAt,
                         post.updatedAt,
-                        isVerifiedExpr
+                        isVerifiedExpr,
+                        isOwnerExpr(providerId)
                 ))
                 .from(post)
                 .leftJoin(post.user)

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -8,7 +8,6 @@ import com.example.trace.global.exception.PostException;
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.gpt.service.PostVerificationService;
-import com.example.trace.post.domain.PostType;
 import com.example.trace.post.domain.cursor.SearchType;
 import com.example.trace.post.dto.cursor.CursorResponse;
 import com.example.trace.post.dto.cursor.PostCursorRequest;
@@ -138,7 +137,6 @@ public class PostServiceImpl implements PostService {
 
         postDto.setEmotionCount(emotionCountDto);
         postDto.setOwner(post.getUser().getProviderId().equals(user.getProviderId()));
-
         postDto.setYourEmotionType(yourEmotionType);
 
         return postDto;
@@ -155,11 +153,11 @@ public class PostServiceImpl implements PostService {
         List<PostFeedDto> posts;
         if (request.getCursorDateTime() == null || request.getCursorId() == null) {
             // 첫 페이지 조회
-            posts = postRepository.findPostsWithCursor(null,null, size + 1, request.getPostType());
+            posts = postRepository.findPostsWithCursor(null,null, size + 1, request.getPostType(),providerId);
         } else {
             // 다음 페이지 조회
             posts = postRepository.findPostsWithCursor(
-                    request.getCursorDateTime(), request.getCursorId(), size + 1, request.getPostType() );
+                    request.getCursorDateTime(), request.getCursorId(), size + 1, request.getPostType(),providerId);
         }
 
 
@@ -218,7 +216,8 @@ public class PostServiceImpl implements PostService {
                     request.getCursorDateTime(),
                     request.getCursorId(),
                     size + 1,
-                    request.getPostType()
+                    request.getPostType(),
+                    providerId
             );
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: dev
+    active: local
   jpa:
     properties:
       hibernate:
@@ -146,7 +146,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local
+    active: dev
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

게시글 작성 직후 emotionCountDto 응답 개선 null 이 아닌 0으로 세팅된 값들

페이징 조회 시, 감정표현 총합 개수 응답에 추가

미션 게시글 조회 시, missionContent에 내용 넣어서 응답

## 2. ✨새롭게 변경된 점

- 게시글 작성 시, emotionCount가 0,0,0,0,0 으로 초기화된 객체를 받는다
- 페이징 조회 시, 응답에 감정표현 총합 개수가 포함된다
- 미션 게시글 조회 시, 할당 받은 미션의 내용도 응답에 포함된다.


## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
