### PR TITLE
feat :  선행 게시글 및 미션 제출 인증 성공 시 선행 점수

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ feature/jiseob/#102 ]
+    branches: [ develop ]
 #테스트6
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,7 @@ name: CI/CD
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ feature/jiseob/#102 ]
 #테스트6
 jobs:
   build:

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                     "/swagger-resources/**",
                     "/webjars/**",
                         "/error/**",
-                        "/health"
+                        "/health",
+                        "/"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/trace/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/trace/auth/config/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                     "/swagger-ui.html",
                     "/swagger-resources/**",
                     "/webjars/**",
-                        "/error/**"
+                        "/error/**",
+                        "/health"
                 ).permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/example/trace/global/errorcode/MissionErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/MissionErrorCode.java
@@ -10,7 +10,8 @@ public enum MissionErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자가 존재하지 않습니다."),
     DAILYMISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자에게 할당된 일일 미션이 없습니다"),
     MISSION_CREATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,"일일 변경 횟수 초과"),
-    RANDOM_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"다른 미션을 찾을 수 없습니다.")
+    RANDOM_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"다른 미션을 찾을 수 없습니다."),
+    VERIFICATION_FAIL(HttpStatus.BAD_REQUEST,"미션 인증에 실패했습니다. 적절한 게시글 내용과 사진을 보내주세요.")
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationService.java
@@ -3,10 +3,11 @@ package com.example.trace.gpt.service;
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
+import com.example.trace.mission.mission.DailyMission;
 import com.example.trace.post.dto.post.PostCreateDto;
 
 public interface PostVerificationService {
     VerificationDto verifyPost(PostCreateDto postCreateDto,String providerId);
     Verification makeVerification(VerificationDto verificationDto);
-    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto, String providerId);
+    VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto,DailyMission assignedDailyMission);
 } 

--- a/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
+++ b/src/main/java/com/example/trace/gpt/service/PostVerificationServiceImpl.java
@@ -1,10 +1,8 @@
 package com.example.trace.gpt.service;
 
 import com.example.trace.global.errorcode.GptErrorCode;
-import com.example.trace.global.errorcode.MissionErrorCode;
 import com.example.trace.global.errorcode.PostErrorCode;
 import com.example.trace.global.exception.GptException;
-import com.example.trace.global.exception.MissionException;
 import com.example.trace.global.exception.PostException;
 import com.example.trace.gpt.domain.Verification;
 import com.example.trace.gpt.dto.VerificationDto;
@@ -28,7 +26,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -57,14 +54,7 @@ public class PostVerificationServiceImpl implements PostVerificationService {
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto,String providerId){
-        LocalDate today = LocalDate.now();
-
-        User user = userRepository.findByProviderId(providerId)
-                .orElseThrow(()->new MissionException(MissionErrorCode.USER_NOT_FOUND));
-
-        DailyMission assignedDailyMission = dailyMissionRepository.findByUserAndDate(user,today)
-                .orElseThrow(()->new MissionException(MissionErrorCode.DAILYMISSION_NOT_FOUND));
+    public VerificationDto verifyDailyMission(SubmitDailyMissionDto submitDto,DailyMission assignedDailyMission){
 
         if (submitDto.getContent() == null || submitDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);

--- a/src/main/java/com/example/trace/mission/dto/DailyMissionResponse.java
+++ b/src/main/java/com/example/trace/mission/dto/DailyMissionResponse.java
@@ -1,6 +1,7 @@
 package com.example.trace.mission.dto;
 
 import com.example.trace.mission.mission.DailyMission;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +14,14 @@ import lombok.NoArgsConstructor;
 public class DailyMissionResponse {
     private String content;
     private int changCount;
+    @JsonProperty("isVerified")
+    private boolean isVerified;
 
     public static DailyMissionResponse fromEntity(DailyMission dailyMission) {
         return DailyMissionResponse.builder()
                 .content(dailyMission.getMission().getDescription())
                 .changCount(dailyMission.getChangeCount())
+                .isVerified(dailyMission.isVerified())
                 .build();
     }
 

--- a/src/main/java/com/example/trace/mission/mission/DailyMission.java
+++ b/src/main/java/com/example/trace/mission/mission/DailyMission.java
@@ -1,6 +1,7 @@
 package com.example.trace.mission.mission;
 
 import com.example.trace.user.User;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,10 +38,18 @@ public class DailyMission {
     @Column(nullable = false)
     private int changeCount;
 
+    @JsonProperty("isVerified")
+    private boolean isVerified;
+
     public void changeMission(Mission newMission) {
         this.mission = newMission;
         this.changeCount++;
     }
+
+    public void updateVerification(boolean isVerified){
+        this.isVerified = isVerified;
+    }
+
 
 
 

--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -148,6 +148,8 @@ public class DailyMissionService {
         if(!verificationDto.isImageResult() && !verificationDto.isTextResult()){
             throw new MissionException(MissionErrorCode.VERIFICATION_FAIL);
         }
+        assignedDailyMission.updateVerification(true);
+
         PostCreateDto postCreateDto = PostCreateDto.builder()
                 .postType(PostType.MISSION)
                 .title(submitDto.getTitle())

--- a/src/main/java/com/example/trace/mission/service/DailyMissionService.java
+++ b/src/main/java/com/example/trace/mission/service/DailyMissionService.java
@@ -138,12 +138,22 @@ public class DailyMissionService {
     }
 
     public PostDto verifySubmissionAndCreatePost(String providerId, SubmitDailyMissionDto submitDto){
-        VerificationDto verificationDto = postVerificationService.verifyDailyMission(submitDto, providerId);
+        User user = userRepository.findByProviderId(providerId)
+                .orElseThrow(()->new MissionException(MissionErrorCode.USER_NOT_FOUND));
+        LocalDate today = LocalDate.now();
+        DailyMission assignedDailyMission = dailyMissionRepository.findByUserAndDate(user,today)
+                .orElseThrow(()-> new MissionException(MissionErrorCode.DAILYMISSION_NOT_FOUND));
+
+        VerificationDto verificationDto = postVerificationService.verifyDailyMission(submitDto, assignedDailyMission);
+        if(!verificationDto.isImageResult() && !verificationDto.isTextResult()){
+            throw new MissionException(MissionErrorCode.VERIFICATION_FAIL);
+        }
         PostCreateDto postCreateDto = PostCreateDto.builder()
                 .postType(PostType.MISSION)
                 .title(submitDto.getTitle())
                 .content(submitDto.getContent())
                 .imageFiles(submitDto.getImageFiles())
+                .missionContent(assignedDailyMission.getMission().getDescription())
                 .build();
         return postService.createPost(postCreateDto,providerId,verificationDto);
     }

--- a/src/main/java/com/example/trace/post/controller/PostController.java
+++ b/src/main/java/com/example/trace/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.example.trace.post.controller;
 
 import com.example.trace.gpt.dto.VerificationDto;
 import com.example.trace.gpt.service.PostVerificationService;
+import com.example.trace.post.domain.PostType;
 import com.example.trace.post.dto.cursor.CursorResponse;
 import com.example.trace.post.dto.cursor.PostCursorRequest;
 import com.example.trace.post.dto.post.PostFeedDto;
@@ -95,6 +96,7 @@ public class PostController {
             int maxImages = Math.min(imageFiles.size(), 5);
             postCreateDto.setImageFiles(imageFiles.subList(0, maxImages));
         }
+        postCreateDto.setPostType(PostType.GOOD_DEED);
         VerificationDto verificationDto = postVerificationService.verifyPost(postCreateDto, providerId);
         PostDto postDto = postService.createPost(postCreateDto,providerId,verificationDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(postDto);

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -63,8 +63,7 @@ public class Post {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "verification_id")
+    @OneToOne(mappedBy = "post",cascade = CascadeType.ALL,orphanRemoval = true)
     private Verification verification;
 
     @Column(name = "mission_content")

--- a/src/main/java/com/example/trace/post/domain/Post.java
+++ b/src/main/java/com/example/trace/post/domain/Post.java
@@ -67,6 +67,9 @@ public class Post {
     @JoinColumn(name = "verification_id")
     private Verification verification;
 
+    @Column(name = "mission_content")
+    private String missionContent;
+
 
     public void addImage(PostImage image) {
         this.images.add(image);

--- a/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostCreateDto.java
@@ -31,6 +31,9 @@ public class PostCreateDto {
     @Schema(description = "게시글 내용", example = "게시글 내용")
     private String content;
 
+    @Schema(description = "할당된 미션 내용", example ="종업원에게 인사하기", hidden = true)
+    private String missionContent;
+
     @JsonIgnore
     private MultipartFile imageFile;
 

--- a/src/main/java/com/example/trace/post/dto/post/PostDto.java
+++ b/src/main/java/com/example/trace/post/dto/post/PostDto.java
@@ -106,6 +106,7 @@ public class PostDto {
                 .profileImageUrl(post.getUser().getProfileImageUrl())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
+                .missionContent(post.getPostType() == PostType.MISSION ? post.getMissionContent() : null)
                 .build();
     }
     

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustom.java
@@ -34,7 +34,8 @@ public interface PostRepositoryCustom {
             int size,
             PostType postType,
             String keyword,
-            SearchType searchType
+            SearchType searchType,
+            String providerId
     );
 
 }

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -11,7 +11,6 @@ import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -52,6 +51,10 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                             .orderBy(postImage.id.asc())
                             .limit(1)
             );
+    Expression<Long> totalEmotionCount = JPAExpressions
+            .select(emotion.count())
+            .from(emotion)
+            .where(emotion.post.eq(post));
 
     BooleanExpression isVerifiedExpr = Expressions.cases()
             .when(post.verification.isNull())
@@ -168,7 +171,8 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
             int size,
             PostType postType,
             String keyword,
-            SearchType searchType) {
+            SearchType searchType,
+            String providerId) {
 
         QPost post = QPost.post;
         QPostImage postImage = new QPostImage("postImage");
@@ -187,7 +191,9 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
                         post.commentList.size().longValue(),
                         post.createdAt,
                         post.updatedAt,
-                        isVerifiedExpr
+                        isVerifiedExpr,
+                        isOwnerExpr(providerId),
+                        totalEmotionCount
                 ))
                 .from(post)
                 .leftJoin(post.user)

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -75,7 +75,7 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
 
-        user.updateVerificationScore(verificationDto);
+        user.updateVerification(verificationDto);
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);
@@ -225,7 +225,8 @@ public class PostServiceImpl implements PostService {
                     size + 1,
                     request.getPostType(),
                     keyword,
-                    request.getSearchType() != null ? request.getSearchType() : SearchType.ALL
+                    request.getSearchType() != null ? request.getSearchType() : SearchType.ALL,
+                    providerId
             );
         } else {
             // 기존 일반 조회 기능 사용

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -75,7 +75,10 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
 
-        user.updateVerification(verificationDto);
+        if(verificationDto != null){
+            user.updateVerification(verificationDto);
+        }
+
 
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -75,6 +75,8 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findByProviderId(ProviderId)
                 .orElseThrow(() -> new PostException(PostErrorCode.USER_NOT_FOUND));
 
+        user.updateVerificationScore(verificationDto);
+
         if (postCreateDto.getContent() == null || postCreateDto.getContent().isEmpty()) {
             throw new PostException(PostErrorCode.CONTENT_EMPTY);
         }
@@ -87,6 +89,7 @@ public class PostServiceImpl implements PostService {
         if(verificationDto != null){
             verification = postVerificationService.makeVerification(verificationDto);
         }
+
 
         Post post = Post.builder()
                 .postType(postCreateDto.getPostType())

--- a/src/main/java/com/example/trace/post/service/PostServiceImpl.java
+++ b/src/main/java/com/example/trace/post/service/PostServiceImpl.java
@@ -136,28 +136,28 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional
-    public PostDto getPostById (Long postId, User user){
+    public PostDto getPostById (Long postId, User requestUser){
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
+        User authorUser = post.getUser();
         LocalDate today = LocalDate.now();
-        DailyMission dailyMission = dailyMissionRepository.findByUserAndDate(user,today)
+        DailyMission authorDailyMission = dailyMissionRepository.findByUserAndDate(authorUser,today)
                 .orElseThrow(()-> new MissionException(MissionErrorCode.DAILYMISSION_NOT_FOUND));
 
         post.incrementViewCount();
 
         EmotionCountDto emotionCountDto = emotionService.getEmotionCountsByType(postId);
 
-        EmotionType yourEmotionType = emotionService.getYourEmotion(postId,user);
+        EmotionType yourEmotionType = emotionService.getYourEmotion(postId,requestUser);
 
         PostDto postDto = PostDto.fromEntity(post);
 
         if(postDto.getPostType() == PostType.MISSION){
-            postDto.setMissionContent(dailyMission.getMission().getDescription());
+            postDto.setMissionContent(authorDailyMission.getMission().getDescription());
         }
 
         postDto.setEmotionCount(emotionCountDto);
-        postDto.setOwner(post.getUser().getProviderId().equals(user.getProviderId()));
+        postDto.setOwner(post.getUser().getProviderId().equals(requestUser.getProviderId()));
         postDto.setYourEmotionType(yourEmotionType);
 
         return postDto;

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -34,6 +34,9 @@ public class User {
     @Builder.Default
     private Long verificationScore = 0L;
 
+    @Builder.Default
+    private Long verificationCount = 0L;
+
     //spring security용으로 일단 두기.
     private String password;
     private String username;
@@ -54,7 +57,8 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
-    public void updateVerificationScore(VerificationDto verificationDto){
+    public void updateVerification(VerificationDto verificationDto){
+        if(verificationDto.isTextResult() || verificationDto.isImageResult()) verificationCount++;
         if(verificationDto.isImageResult()) this.verificationScore += 10;
         if(verificationDto.isTextResult()) this.verificationScore += 5;
     }

--- a/src/main/java/com/example/trace/user/User.java
+++ b/src/main/java/com/example/trace/user/User.java
@@ -1,5 +1,6 @@
 package com.example.trace.user;
 
+import com.example.trace.gpt.dto.VerificationDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -30,6 +31,9 @@ public class User {
 
     private String profileImageUrl;
 
+    @Builder.Default
+    private Long verificationScore = 0L;
+
     //spring security용으로 일단 두기.
     private String password;
     private String username;
@@ -50,4 +54,8 @@ public class User {
         this.profileImageUrl = newProfileImageUrl;
     }
 
+    public void updateVerificationScore(VerificationDto verificationDto){
+        if(verificationDto.isImageResult()) this.verificationScore += 10;
+        if(verificationDto.isTextResult()) this.verificationScore += 5;
+    }
 }

--- a/src/main/java/com/example/trace/user/UserService.java
+++ b/src/main/java/com/example/trace/user/UserService.java
@@ -53,9 +53,7 @@ public class UserService {
         User user = userRepository.findByProviderId(providerId)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        if (imageUrl != null) {
-            user.updateProfileImageUrl(imageUrl);
-        }
+        user.updateProfileImageUrl(imageUrl);
         userRepository.save(user);
         return UserDto.fromEntity(user);
     }

--- a/src/main/java/com/example/trace/user/dto/UserDto.java
+++ b/src/main/java/com/example/trace/user/dto/UserDto.java
@@ -20,6 +20,8 @@ public class UserDto {
     String email;
     @Schema(description = "선행 점수")
     Long verificationScore;
+    @Schema(description = "선행 인증 개수")
+    Long verificationCount;
 
     public static UserDto fromEntity(User user) {
         return UserDto.builder()
@@ -27,6 +29,7 @@ public class UserDto {
                 .profileImageUrl(user.getProfileImageUrl())
                 .email(user.getEmail())
                 .verificationScore(user.getVerificationScore())
+                .verificationCount(user.getVerificationCount())
                 .build();
     }
 }

--- a/src/main/java/com/example/trace/user/dto/UserDto.java
+++ b/src/main/java/com/example/trace/user/dto/UserDto.java
@@ -18,12 +18,15 @@ public class UserDto {
     String profileImageUrl;
     @Schema(description = "이메일")
     String email;
+    @Schema(description = "선행 점수")
+    Long verificationScore;
 
     public static UserDto fromEntity(User user) {
         return UserDto.builder()
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
                 .email(user.getEmail())
+                .verificationScore(user.getVerificationScore())
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,7 +99,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
       hibernate:
         jdbc:
           time_zone: Asia/Seoul
+        timezone:
+          default_storage: NORMALIZE
   # 한국 시간대 설정 추가
   jackson:
     time-zone: Asia/Seoul

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring:
   jackson:
     time-zone: Asia/Seoul
     date-format: yyyy-MM-dd HH:mm:ss
+    serialization:
+      write-dates-as-timestamps: false
 
 # AWS S3 설정
 cloud:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: dev
+    active: local
   jpa:
     properties:
       hibernate:
@@ -105,6 +105,22 @@ spring:
         format_sql: true
         show_sql: false
         dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          time_zone: Asia/Seoul
+          batch_size: 20
+        timezone:
+          default_storage: NORMALIZE
+        order_inserts: true
+        order_updates: true
+        query:
+          plan_cache_max_size: 64
+
+  # 한국 시간대 설정 추가 (dev 프로파일에서 누락되었던 부분)
+  jackson:
+    time-zone: Asia/Seoul
+    date-format: yyyy-MM-dd HH:mm:ss
+    serialization:
+      write-dates-as-timestamps: false
 
   sql:
     init:
@@ -122,6 +138,18 @@ server:
     include-exception: false
   tomcat:
     basedir: ./temp  # Custom temp directory for Tomcat
+    max-http-form-post-size: 2MB
+    max-swallow-size: 2MB
+
+# 메모리 사용량 최적화를 위한 JVM 설정
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
 
 ---
 
@@ -156,6 +184,17 @@ spring:
       hibernate:
         format_sql: true
         use_sql_comments: true
+        jdbc:
+          time_zone: Asia/Seoul
+        timezone:
+          default_storage: NORMALIZE
+
+  # 로컬에서도 시간대 설정 일관성 유지
+  jackson:
+    time-zone: Asia/Seoul
+    date-format: yyyy-MM-dd HH:mm:ss
+    serialization:
+      write-dates-as-timestamps: false
 
   app:
     base-url: http://localhost:8080/api/v1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: local
+    active: dev
   jpa:
     properties:
       hibernate:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

게시글을 선행 인증 체크하여 생성하고 성공했을 시, 사용자의 선행 마크 개수와 선행 점수가 증가

미션 제출 시에도 같음. 

게시글 조회 시, 조회 사용자에게 할당된 일일미션을 확인하는 로직 오류가 있었는데

게시글 엔티티에 미션 내용 필드를 추가하여 미션 게시글 생성 시, 미션 내용이 추가되고

게시글 조회 시, 일일 미션 조회할 필요없이 미션 내용을 확인할 수 있다.

POST와 VERIFICATION 엔티티를 순환참조 하고 있어서 삭제가 안됐는데, 수정하였다. 



## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
