### PR TITLE
fix : 자잘한 수정 사항 적용

### DIFF
--- a/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
@@ -139,6 +139,7 @@ public class KakaoOAuthService {
                     .user(newUser)
                     .date(today)
                     .changeCount(0)
+                    .isVerified(false)
                     .build();
 
             dailyMissionRepository.save(signUpDailyMission);

--- a/src/main/java/com/example/trace/global/errorcode/MissionErrorCode.java
+++ b/src/main/java/com/example/trace/global/errorcode/MissionErrorCode.java
@@ -11,7 +11,8 @@ public enum MissionErrorCode implements ErrorCode {
     DAILYMISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"사용자에게 할당된 일일 미션이 없습니다"),
     MISSION_CREATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,"일일 변경 횟수 초과"),
     RANDOM_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND,"다른 미션을 찾을 수 없습니다."),
-    VERIFICATION_FAIL(HttpStatus.BAD_REQUEST,"미션 인증에 실패했습니다. 적절한 게시글 내용과 사진을 보내주세요.")
+    VERIFICATION_FAIL(HttpStatus.BAD_REQUEST,"미션 인증에 실패했습니다. 적절한 게시글 내용과 사진을 보내주세요."),
+    ALREADY_VERIFIED(HttpStatus.BAD_REQUEST,"오늘 미션 인증을 이미 완료 하셨습니다.");
     ;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/trace/gpt/domain/Verification.java
+++ b/src/main/java/com/example/trace/gpt/domain/Verification.java
@@ -30,8 +30,10 @@ public class Verification {
 
     private boolean isImageVerified;
 
+    @Column(columnDefinition = "TEXT")
     private String failureReason;
 
+    @Column(columnDefinition = "TEXT")
     private String successReason;
 
     public void connectToPost(Post post){

--- a/src/main/java/com/example/trace/mission/dto/DailyMissionResponse.java
+++ b/src/main/java/com/example/trace/mission/dto/DailyMissionResponse.java
@@ -2,25 +2,28 @@ package com.example.trace.mission.dto;
 
 import com.example.trace.mission.mission.DailyMission;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
+@Data
 @Builder
+@Schema(description = "미션 응답")
 public class DailyMissionResponse {
+    @Schema(name = "미션 내용", example = "대중교통에서 자리 양보하기")
     private String content;
-    private int changCount;
+    @Schema(name = "할당 받은 미션 변경 횟수", example = "4")
+    private int changeCount;
+
+    @Schema(name = "미션 인증 여부", example = "false")
     @JsonProperty("isVerified")
     private boolean isVerified;
 
     public static DailyMissionResponse fromEntity(DailyMission dailyMission) {
         return DailyMissionResponse.builder()
                 .content(dailyMission.getMission().getDescription())
-                .changCount(dailyMission.getChangeCount())
+                .changeCount(dailyMission.getChangeCount())
                 .isVerified(dailyMission.isVerified())
                 .build();
     }

--- a/src/main/java/com/example/trace/mission/mission/DailyMission.java
+++ b/src/main/java/com/example/trace/mission/mission/DailyMission.java
@@ -38,7 +38,7 @@ public class DailyMission {
     @Column(nullable = false)
     private int changeCount;
 
-    @JsonProperty("isVerified")
+    @Column(name="is_verified")
     private boolean isVerified;
 
     public void changeMission(Mission newMission) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -178,7 +178,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

- DailyMissionResponse의 isVerified 변수가 두 개 응답으로 보내지는 이슈.

- changCount 로 변수명의 오타

- 인증 api에서 Verification db 저장 시, text가 너무 긴 이슈 수정

- DailyMission 생성 시, isVerified 세팅을 안해서 응답 생성 시, null 값을 참조했던 이슈

- 할당 시간 전에 회원 가입했을 경우, 할당받았던 미션이 정기 할당으로 인해 변경되지 않기 위한 로직 개선


## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
