### PR TITLE
fix : 자잘한 수정사항 적용 및 미션 공백 시간 처리

### DIFF
--- a/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
+++ b/src/main/java/com/example/trace/mission/controller/DailyMissionController.java
@@ -1,13 +1,17 @@
 package com.example.trace.mission.controller;
 
+import com.example.trace.auth.repository.UserRepository;
 import com.example.trace.gpt.service.PostVerificationService;
 import com.example.trace.mission.dto.AssignMissionRequest;
 import com.example.trace.mission.dto.SubmitDailyMissionDto;
 import com.example.trace.mission.service.DailyMissionService;
 import com.example.trace.mission.dto.DailyMissionResponse;
 import com.example.trace.auth.dto.PrincipalDetails;
+import com.example.trace.mission.util.MissionDateUtil;
 import com.example.trace.post.dto.post.PostDto;
 import com.example.trace.post.service.PostService;
+import com.example.trace.user.User;
+import com.example.trace.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
@@ -23,6 +27,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
@@ -34,6 +39,7 @@ import java.util.List;
 public class DailyMissionController {
 
     private final DailyMissionService missionService;
+    private final UserService userService;
 
     /**
      * 오늘 할당된 미션을 사용자에게 반환합니다.
@@ -58,7 +64,9 @@ public class DailyMissionController {
     @PostMapping("/assign/test")
     public ResponseEntity<DailyMissionResponse> assignDailyMissionsToUserForTest(@RequestBody AssignMissionRequest request){
         String providerId = request.getProviderId();
-        return ResponseEntity.ok(missionService.assignDailyMissionsToUserForTest(providerId));
+        User user = userService.getUser(providerId);
+        LocalDate missionDate = MissionDateUtil.getMissionDate();
+        return ResponseEntity.ok(missionService.assignDailyMissionsToUser(user,missionDate));
     }
 
     @PostMapping(value ="/submit",consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/example/trace/mission/util/MissionDateUtil.java
+++ b/src/main/java/com/example/trace/mission/util/MissionDateUtil.java
@@ -1,0 +1,17 @@
+package com.example.trace.mission.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class MissionDateUtil {
+    private static final int MISSION_START_HOUR = 7;
+
+    public static LocalDate getMissionDate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (now.getHour() < MISSION_START_HOUR) {
+            // 오전 7시 이전이면 전날 미션을 조회
+            return now.toLocalDate().minusDays(1);
+        }
+        return now.toLocalDate();
+    }
+}

--- a/src/main/java/com/example/trace/user/UserService.java
+++ b/src/main/java/com/example/trace/user/UserService.java
@@ -34,6 +34,13 @@ public class UserService {
         return UserDto.fromEntity(user);
     }
 
+    public User getUser(String providerId){
+        User user = userRepository.findByProviderId(providerId)
+                .orElseThrow(()->new UserException(UserErrorCode.USER_NOT_FOUND));
+        return user;
+    }
+
+
     @Transactional
     public UserDto updateUserNickName(User user,UpdateNickNameRequest request){
         String newNickname = request.getNickname();
@@ -58,9 +65,6 @@ public class UserService {
         return UserDto.fromEntity(user);
     }
 
-    /**
-     * 모든 사용자 목록을 조회합니다.
-     */
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
   application:
     name: Trace
   profiles:
-    active: dev
+    active: local
   jpa:
     properties:
       hibernate:
@@ -99,7 +99,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -178,7 +178,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

오전 7시에 미션이 할당된다고 할 때,

미션을 당일날짜로 조회하면 자정부터 아침 7시까지 미션 공백상태가 된다.

회원 가입 시, 바로 미션을 할당하는데 회원 가입 후 너무 이른 시간내에 미션이 할당되는 것을 막으면

24시간 기준으로 조회하는것도 애매해진다.

만약 당일 기준이 아닌 24시간 이내에 할당된 미션을 조회하여 해결한다면

회원가입을 오전 6시에 했을 시, 오전 6시에 미션이 할당된다.

그렇다면 다음날 오전 6시부터 7시까지 유저의 미션이 공백 상태가 된다.

이러한 미션 공백을 막아야한다.

-> 할당된 미션 조회 시, MissionDateUtil을 사용하여
현재 시간이 오전 7시 전이라면, 전날 기준으로 미션을 조회하도록 구현하였다.
그 외라면 당일 기준 미션 조회


## 2. ✨새롭게 변경된 점

- 매일 오전 7시에 미션 할당
- 회원 가입 시, 즉시 할당
- 할당된 미션 조회 시, 공백 시간 없어짐
- 미션 할당 시, 사용자가 오늘자로 할당된 미션이 있다면 넘기기 (오전 7시전 회원가입한 유저)

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
