### PR TITLE
fix : fcm 저장 api 따로 두기

### DIFF
--- a/src/main/java/com/example/trace/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/example/trace/auth/dto/request/KakaoLoginRequest.java
@@ -16,9 +16,4 @@ public class KakaoLoginRequest {
     @NotBlank
     @Schema(description = "ID 토큰", example = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwicm9sZSI6IlJPTEVfVVNFUiIsI...")
     private String idToken;
-
-    @NotBlank
-    @Schema(description = "fcm 토큰")
-    private String fcmToken;
-
 }

--- a/src/main/java/com/example/trace/auth/dto/request/KakaoSignupRequest.java
+++ b/src/main/java/com/example/trace/auth/dto/request/KakaoSignupRequest.java
@@ -18,10 +18,6 @@ public class KakaoSignupRequest {
     private String signupToken; // 임시 회원가입 토큰
 
     @NotBlank
-    @Schema(description = "fcm 토큰")
-    private String fcmToken;
-
-    @NotBlank
     @Schema(description = "회원가입을 위한 providerId", example = "415367..")
     private String providerId;
 

--- a/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/trace/auth/service/KakaoOAuthService.java
@@ -91,11 +91,6 @@ public class KakaoOAuthService {
             String accessToken = generateAccessToken(user);
             String refreshToken = generateRefreshToken(user);
 
-            String providreId = user.getProviderId();
-            String fcmToken = request.getFcmToken();
-
-            fcmTokenService.saveOrUpdateToken(providreId,fcmToken);
-
             return ResponseEntity.ok(new TokenResponse(accessToken, refreshToken));
         } else {
             // 사용자 없으면 레디스에 임시 회원가입 토큰 저장
@@ -139,11 +134,6 @@ public class KakaoOAuthService {
                     .build();
 
             userRepository.save(newUser);
-
-            String newUserProviderId = newUser.getProviderId();
-            String fcmToken = request.getFcmToken();
-
-            fcmTokenService.saveOrUpdateToken(newUserProviderId,fcmToken);
 
             Mission randomMission = missionRepository.findRandomMission();
             LocalDate today = LocalDate.now();

--- a/src/main/java/com/example/trace/global/fcm/FcmTokenController.java
+++ b/src/main/java/com/example/trace/global/fcm/FcmTokenController.java
@@ -2,6 +2,7 @@ package com.example.trace.global.fcm;
 
 import com.example.trace.auth.dto.PrincipalDetails;
 import com.example.trace.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/fcm")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "fcm 토큰", description = "fcm 토큰 저장 API")
 public class FcmTokenController {
 
     private final FcmTokenService fcmTokenService;
@@ -21,7 +23,7 @@ public class FcmTokenController {
 
     @PostMapping("/tokens")
     public ResponseEntity<?> saveToken(
-            @AuthenticationPrincipal PrincipalDetails principalDetails, // 실제로는 인증된 사용자 정보에서 가져오는 것이 좋습니다
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
             @Valid @RequestBody FcmTokenRequest request) {
 
         String providerId = principalDetails.getUser().getProviderId();


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

## 2. ✨새롭게 변경된 점

로그인이나 회원 가입 시, fcm 토큰을 같이 보내는게 아닌

api를 따로 두어 로그인이나 회원 가입 성공 시 요청을 한번 더 보내 fcm 토큰을 저장하도록 바꾸었다.

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
