### PR TITLE
refactor : 마이페이지 탭 별로 조회 기능

### DIFF
--- a/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
+++ b/src/main/java/com/example/trace/post/dto/cursor/PostCursorRequest.java
@@ -2,8 +2,8 @@ package com.example.trace.post.dto.cursor;
 
 import com.example.trace.post.domain.PostType;
 import com.example.trace.post.domain.cursor.SearchType;
+import com.example.trace.user.dto.MyPageTab;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +24,8 @@ public class PostCursorRequest {
     private Integer size = 10; // 기본 페이지 크기
     @Schema(description = "게시글 타입", example = "MISSION")
     private PostType postType; // 필터링을 위한 게시글 타입 (선택적)
+    @Schema(description = "마이페이지 탭", example = "WRITTEN_POSTS,COMMENTED_POSTS,REACTED_POSTS")
+    private MyPageTab myPageTab; // 마이페이지에서 어떤 탭을 볼지에 대한 페이지 탭 타입
 
     // 검색을 위한 필드
     @Schema(description = "검색 키워드", example = "")

--- a/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/example/trace/post/repository/PostRepositoryCustomImpl.java
@@ -41,7 +41,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom{
     }
 
     StringExpression imageUrlExpr = Expressions.cases()
-            .when(post.images.isEmpty()).then("")
+            .when(post.images.isEmpty()).then(Expressions.stringTemplate("null"))
             .otherwise(
                     JPAExpressions
                             .select(postImage.imageUrl)

--- a/src/main/java/com/example/trace/post/service/PostService.java
+++ b/src/main/java/com/example/trace/post/service/PostService.java
@@ -29,4 +29,6 @@ public interface PostService {
 
     CursorResponse<PostFeedDto> getUserEmotedPostsWithCursor(PostCursorRequest request, String providerId);
 
+    CursorResponse<PostFeedDto> getMyPagePostsWithCursor(PostCursorRequest request, String providerId);
+
 } 

--- a/src/main/java/com/example/trace/user/UserController.java
+++ b/src/main/java/com/example/trace/user/UserController.java
@@ -116,33 +116,14 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/myPost")
-    @Operation(summary = "내 게시글 커서 기반 페이징 조회", description = "커서 기반 페이징으로 내 게시글을 조회합니다.")
-    public ResponseEntity<CursorResponse<PostFeedDto>> getMyPosts(
-            @RequestBody PostCursorRequest request,
-            @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        String providerId = principalDetails.getUser().getProviderId();
-        CursorResponse<PostFeedDto> response = postService.getMyPostsWithCursor(request, providerId);
-        return ResponseEntity.ok(response);
-    }
 
-    @PostMapping("/myCommentedPosts")
-    @Operation(summary = "내가 댓글 단 게시글 커서 기반 페이징 조회", description = "커서 기반 페이징으로 내가 댓글을 단 게시글을 조회합니다.")
-    public ResponseEntity<CursorResponse<PostFeedDto>> getMyCommentedPosts(
+    @PostMapping("/myPosts")
+    @Operation(summary = "마이페이지 게시글 조회", description = "탭 별로 마이페이지 게시글을 조회합니다.")
+    public ResponseEntity<CursorResponse<PostFeedDto>> getMyPagePosts(
             @RequestBody PostCursorRequest request,
             @AuthenticationPrincipal PrincipalDetails principalDetails) {
         String providerId = principalDetails.getUser().getProviderId();
-        CursorResponse<PostFeedDto> response = postService.getUserCommentedPostsWithCursor(request, providerId);
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/myEmotionPosts")
-    @Operation(summary = "내가 감정표현한 게시글 커서 기반 페이징 조회", description = "커서 기반 페이징으로 내가 감정표현을 한 게시글을 조회합니다.")
-    public ResponseEntity<CursorResponse<PostFeedDto>> getMyEmotedPosts(
-            @RequestBody PostCursorRequest request,
-            @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        String providerId = principalDetails.getUser().getProviderId();
-        CursorResponse<PostFeedDto> response = postService.getUserEmotedPostsWithCursor(request, providerId);
+        CursorResponse<PostFeedDto> response = postService.getMyPagePostsWithCursor(request, providerId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/trace/user/dto/MyPageTab.java
+++ b/src/main/java/com/example/trace/user/dto/MyPageTab.java
@@ -1,0 +1,20 @@
+package com.example.trace.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyPageTab {
+    WRITTEN_POSTS("나의 흔적"),
+    COMMENTED_POSTS("댓글단 글"),
+    REACTED_POSTS("반응한 글")
+    ;
+
+    private String description;
+
+    MyPageTab(String description){
+        this.description = description;
+    }
+
+}


### PR DESCRIPTION
## 1. 📄 관련된 이슈 및 소개

원래 내가 쓴 글, 감정표현한 글, 댓글 쓴 글 조회하는 api 각각 url이 달랐는데

MyPageTab enum을 요청 dto에 추가하여 enum 상수마다 각자의 조회를 하도록 api를 합쳤다.

## 2. ✨새롭게 변경된 점

## 3. 🔖 기타 사항

## 4. 📸 스크린샷(선택)

## 5. 💡알게된 혹은 궁금한 사항들
